### PR TITLE
feat(core): implement universal login message for all VMs

### DIFF
--- a/configs/docker/vde-base.Dockerfile
+++ b/configs/docker/vde-base.Dockerfile
@@ -53,10 +53,25 @@ RUN mkdir -p /home/devuser/.ssh/vde && \
     chmod 700 /home/devuser/.ssh && \
     chmod 700 /home/devuser/.ssh/vde
 
-# 6. The Atomic Handshake (Entrypoint)
+# 6. THE ATOMIC HANDSHAKE (Entrypoint)
 COPY scripts/vde-entrypoint.zsh /usr/local/bin/vde-entrypoint.zsh
 RUN sudo chmod +x /usr/local/bin/vde-entrypoint.zsh
 
+# 7. Universal Login Message
+USER root
+RUN cat >> /etc/zsh/zlogin <<'EOF'
+# VDE Universal Login Message (Guarded for Interactive Use)
+if [[ -t 1 ]] && [[ -o interactive ]]; then
+    echo "Hostname: ${HOST:-$(hostname)}"
+    echo "User: ${USERNAME:-$(whoami)}"
+    echo "Home Dir: ${HOME}"
+    echo "Shell: ${SHELL}"
+    echo "Workspace: ${HOME}/workspace"
+fi
+EOF
+
+USER devuser
 WORKDIR /home/devuser/workspace
 ENTRYPOINT ["/usr/local/bin/vde-entrypoint.zsh"]
+
 

--- a/docs/superpowers/specs/2026-04-14-universal-login-message-design.md
+++ b/docs/superpowers/specs/2026-04-14-universal-login-message-design.md
@@ -1,0 +1,34 @@
+# Design Spec: Universal VM Login Message
+
+**Date:** 2026-04-14
+**Status:** Approved
+**Target:** Sovereign Baseline 1.3.1
+
+## 1. Goal
+Implement a consistent login message for all users across all VDE VMs (Base, Language, Service).
+
+## 2. Technical Strategy
+Inject the login message logic into the `vde-base` layer via `/etc/zsh/zlogin`. This ensures that every login shell outputs the required metadata automatically.
+
+## 3. Implementation Details
+The following block will be appended to `/etc/zsh/zlogin` in the `vde-base.Dockerfile`:
+
+```zsh
+# VDE Universal Login Message
+echo "Hostname: $(hostname)"
+echo "User: $(whoami)"
+echo "Home Dir: $HOME"
+echo "Shell: $SHELL"
+echo "Workspace: $HOME/workspace"
+```
+
+## 4. Verification Plan
+1. Rebuild the base image: `bin/vde rebuild --vm base`.
+2. Start a VM (e.g., `python`).
+3. Enter the VM: `bin/vde enter python`.
+4. Verify the output matches the specification.
+
+## 5. Compliance
+- **ZSH Purity**: Uses native ZSH login mechanisms.
+- **DRY**: Implemented once in the base image, inherited by all spokes.
+- **Sovereign Baseline**: Aligned with 1.3.1 environment standards.


### PR DESCRIPTION
Closes #10

## Archive of the Strike
This Chronicle records the implementation of a consistent, interactive-guarded login message for all VDE VMs.

## Heartbeat & Proof of Life
- **Empirical Build**: SUCCESS (vde-base:latest built with Section 7 active)
- **Code Review**: PASS (Refined logic with root permissions and ZSH-native variables)
- **Protocol Safety**: Verified interactive-guard implementation to protect scp/rsync.

## Summary by Sourcery

Introduce a universal, interactive-only login message across all VDE-based VMs by configuring it in the base Docker image and documenting the design.

New Features:
- Display a standard login banner showing host, user, home directory, shell, and workspace for interactive ZSH sessions in all VDE VMs.

Documentation:
- Add a design specification documenting the universal VM login message approach, implementation, and verification steps.