### PR TITLE
docs(readme): document develop as default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A sovereign, template-based ecosystem of Dockerized Spokes. Supporting 19+ Language Spokes and 7+ Service Spokes, forged for the warrior who demands consistent hydration and absolute isolation. Accessible via **The Sovereign Baseline (SSH)** with a single, unyielding identity.
 
+**🛡️ The Sovereign Record:** The default branch for this Forge is `develop` (The Anvil). For the stable, certified **Sovereign Baseline**, ensure you clone or switch to the `main` branch.
+
 **The Language of the Tribe:** Strictly **ZSH 5.0+**. No bash-isms, no shortcuts. [See Requirements](docs/requirements.md)
 
 ---


### PR DESCRIPTION
Closes #17

## Archive of the Strike
This Chronicle records the addition of a prominent notice to README.md regarding the repository's default branch alignment.

## Heartbeat & Proof of Life
### Empirical Verification
The README.md now contains the mandated notice:
> **🛡️ The Sovereign Record:** The default branch for this Forge is `develop` (The Anvil). For the stable, certified **Sovereign Baseline**, ensure you clone or switch to the `main` branch.

## Summary by Sourcery

Documentation:
- Add a prominent notice to the README explaining that `develop` is the default branch and `main` is the stable baseline branch.