### PR TITLE
docs: detail develop as default branch in installation guides

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -70,13 +70,15 @@ To walk the Way on Windows, you must build a sanctuary that speaks the **Languag
 
 ### Final Step: Clone & Init
 
+**🛡️ The Sovereign Record:** The default branch for this repository is `develop`. For the stable, certified **Sovereign Baseline**, ensure you clone using the `-b main` flag as shown below.
+
 Once the pillars are active, open your **Zsh** terminal and run:
 
 ```zsh
 # Clone the repository
 git clone -b main https://github.com/dderyldowney/vde-system.git ~/vde
 cd ~/vde
-
+...
 # Add VDE to your PATH
 echo 'export PATH="$HOME/vde/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc

--- a/VDE_INSTALL.md
+++ b/VDE_INSTALL.md
@@ -35,6 +35,8 @@ The VDE Hub uses the **Sovereign Baseline** to connect you to your Spokes.
 ## 2. Installation Ritual (Step-by-Step)
 
 ### Step 1: Clone the Beskar Hub
+**🛡️ The Sovereign Record:** The default branch for this repository is `develop`. For the stable, certified **Sovereign Baseline**, ensure you clone using the `-b main` flag as shown below.
+
 Open your terminal (Zsh) and clone the VDE repository.
 
 ```zsh


### PR DESCRIPTION
Closes #19

## Archive of the Strike
This Chronicle records the alignment of core documentation (VDE_INSTALL.md and USER_GUIDE.md) with the new default branch configuration.

## Heartbeat & Proof of Life
### Empirical Verification
- VDE_INSTALL.md updated with Sovereign Record notice.
- USER_GUIDE.md updated with Sovereign Record notice.
- Instructions for cloning 'main' are clearly documented.

## Summary by Sourcery

Document the repository's default branch as `develop` while clarifying that installation and usage instructions target the stable `main` branch.

Documentation:
- Update USER_GUIDE.md to explain that `develop` is the default branch and that users should clone the stable `main` branch with `-b main`.
- Update VDE_INSTALL.md to note `develop` as the default branch and direct users to clone the `main` branch for the stable Sovereign Baseline.