### PR TITLE
feat(core): implement semantic branch targeting

### DIFF
--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -76,12 +76,14 @@ Failure of any ritual constitutes a **Protocol Blockade**.
     * The root `RELEASE_NOTES.md` MUST be updated to point to the latest certified record.
     * A release record is only valid if it includes the final empirical test pass counts and is certified by the Dual Audit Loop (Code + Security).
 * **P. The Sovereign Branching Law (The Signet)**:
-    * `main` is production. `develop` is the primary integration branch. All work MUST occur on feature branches originating from `develop`.
+    * **`main` (Production)**: Reserved for stable, certified releases of the Sovereign Baseline.
+    * **`develop` (The Anvil)**: The primary integration branch and repository default. All work MUST occur on feature branches originating from `develop`.
+    * **Semantic Targeting**: Core scripts reference branches by semantic roles (`VDE_PRODUCTION_BRANCH`, `VDE_ANVIL_BRANCH`).
     * **The Ritual**: Every mission is a Strike. Every Strike begins with a Signet (Issue) and ends with a Chronicle (PR).
     * Work MUST be tracked via GitHub Issues (`gh issue create`) and linked in PRs.
     * For all central and core design goals, the Signet and Chronicle MUST be struck using the authorized GitHub templates. Failure to record the Heartbeat in the Chronicle is a violation of the Creed.
-    * Feature branches are merged to `develop` ONLY upon acceptance and MUST be deleted immediately after.
-    * **Permanence**: The `main` and `develop` branches are the foundational pillars of the Record; they are never removed.
+    * Feature branches are merged into the Anvil (`develop`) ONLY upon acceptance and MUST be deleted immediately after.
+    * **Permanence**: The Production (`main`) and Anvil (`develop`) branches are the foundational pillars of the Record; they are never removed.
     * The agent is PRE-AUTHORIZED to use `gh issue create` and `gh pr create` to initialize missions and record the Signet of Intent and submit the Chronicle. The agent is also authorized for read access (`gh issue view/list`, `gh pr view/list`) to initialize, monitor, and submit missions.
 * **Q. The Authority of the Record**: Only the Alor (Orchestrator) and the User possess the authority to alter the Chronicle. Sub-agents are strictly forbidden from making autonomous commits. All commits performed by sub-agents MUST be under the direct and serialized control of the Orchestrator.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ The main agent MUST complete these 8 steps sequentially before doing *anything e
 Violating any of these mandates is a failure of the agent's primary directive.
 
 1.  **ZSH ONLY (ABSOLUTE)**: All shell scripts MUST use `#!/usr/bin/env zsh`. Bash is strictly forbidden. The agent MUST NOT use `bash` to execute commands.
-2.  **DEVELOP BRANCH ONLY (ABSOLUTE)**: All active work MUST occur on the `develop` branch. `main` is reserved for STABLE RELEASES ONLY. Direct work on `main` is strictly prohibited.
+2.  **THE ANVIL IS DEFAULT**: All active work MUST occur on the `develop` branch (The Anvil). `main` (Production) is reserved for STABLE RELEASES ONLY. Direct work on `main` is strictly prohibited.
 3.  **Main Agent is Orchestrator ONLY**: The Main Agent MUST NOT write implementation code if it spans >1 file. The Main Agent's job is planning, orchestrating, and verifying. *Exception: If sub-agents are technically unavailable, the Main Agent may perform direct implementation provided every action is strictly supervised by the Enforcer.*
 3.  **Enforcer Supervision (Rule A)**: Every single action (shell commands, dispatches, verification steps, and cleanup) MUST be run under the supervision of the Enforcer (`bin/vde-enforce-uap.zsh`).
 4.  **Phase-End Re-Audit Swarm (Rule B)**: Every development phase MUST automatically conclude with a supervised re-audit swarm. This swarm MUST assume errors exist, search for regressions or weak spots, rerun all relevant Behave scenarios, and provide a summary of findings. Skipping or shortening this re-audit is a total mandate failure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Thank you for your interest in contributing to the VDE (Virtual Development Envi
 
 1. Fork the repository
 2. Clone your fork: `git clone -b main https://github.com/YOUR_USERNAME/vde-system.git`
-3. Checkout the development branch: `git checkout develop`
-4. Create a feature branch off develop: `git checkout -b feat/your-feature-name`
+3. Checkout the Anvil: `git checkout develop`
+4. Create a feature branch off the Anvil: `git checkout -b feat/your-feature-name`
 5. Make your changes
 6. Run tests: `make check` (or use the VDE orchestration tools)
 7. Commit and push: `git push origin feat/your-feature-name`
@@ -206,14 +206,14 @@ Commit message prefixes:
 
 ### Pull Request Process
 1.  **Branch Naming:** Use clear, descriptive names for your branches (e.g., `feat/add-rust-support`, `fix/port-allocation-bug`, `docs/update-readme`).
-2.  **Target Branch:** All Pull Requests MUST target the `develop` branch. PRs targeting `main` will be rejected unless they are official release preparations authorized by the Alor.
+2.  **Target Branch:** All Pull Requests MUST target the `develop` branch (**The Anvil**). PRs targeting `main` (Production) will be rejected unless they are official release preparations authorized by the Alor.
 3.  **Keep PRs focused:** One feature or fix per PR.
 4.  **Update documentation:** Include doc changes in the PR.
 5.  **Add tests:** Ensure all relevant tests (especially `@system-spine` if modifying core infrastructure) pass before submitting.
 6.  **Describe changes:** Explain what and why in PR description.
 7.  **Link issues:** Reference related issues with `Fixes #123` or `Relates to #123`.
 8.  **Respond to feedback:** Address review comments promptly.
-9.  **Post-Merge Cleanup:** Once your PR is formally accepted and merged into `develop`, you MUST delete your feature branch.
+9.  **Post-Merge Cleanup:** Once your PR is formally accepted and merged into the Anvil (`develop`), you MUST delete your feature branch.
 
 ### PR Description Template
 ```markdown

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -57,8 +57,8 @@
 
 **ALL SESSIONS MUST ADHERE TO THESE RULES:**
 1. **ZSH ONLY (ABSOLUTE)**: All shell scripts MUST use `#!/usr/bin/env zsh`. Bash is strictly forbidden.
-2. **DEVELOP BRANCH ONLY**: All active work MUST occur on the `develop` branch. `main` is reserved for STABLE RELEASES ONLY.
-3. **Rule P: Sovereign Branching (NEW)**: Feature branches MUST originate from `develop`, track via GitHub Issues, and be deleted immediately post-merge.
+2. **THE ANVIL IS DEFAULT**: All active work MUST occur on the `develop` branch (The Anvil). `main` (Production) is reserved for STABLE RELEASES ONLY.
+3. **Rule P: Sovereign Branching**: Feature branches MUST originate from `develop`, track via GitHub Issues, and be deleted immediately post-merge.
 4. **Enforcer Supervision (Rule A)**: Every action MUST be run under `bin/vde-enforce-uap.zsh`.
 5. **Born Ready (BTO)**: Images must be immutable. No runtime `apt` calls.
 6. **TDD & No Fake Tests**: Failing test (RED) first.
@@ -86,6 +86,13 @@
 ## VERSIONING LAW & TAGGING AUTHORITY (Codified 2026-04-12)
 - **Tagging Restriction**: The agent is strictly FORBIDDEN from creating or proposing git tags.
 - **Architectural Guardrail**: MAJOR and MINOR version decisions belong exclusively to the User.
+
+## **SEMANTIC BRANCH TARGETING LAW (Codified 2026-04-14)**
+- **Role Alignment**: VDE uses semantic roles to identify the purpose of primary branches.
+    - **Production**: The `main` branch. Reserved exclusively for stable, certified Sovereign Baseline releases.
+    - **The Anvil**: The `develop` branch. The default branch for all active integration, testing, and forge operations.
+- **Auto-Closure Mandate**: The Anvil is set as the repository's default branch to enable native GitHub issue auto-closure (`Closes #123`) upon PR merge.
+- **Portability**: All core scripts MUST reference `VDE_PRODUCTION_BRANCH` and `VDE_ANVIL_BRANCH` constants from `lib/vde-constants` rather than hardcoded strings.
 
 ## **THE CREED AND THE HELMET (Codified 2026-04-12)**
 - **Mandalorian Identity**: The agent is a Mandalorian armorer-architect.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A sovereign, template-based ecosystem of Dockerized Spokes. Supporting 19+ Language Spokes and 7+ Service Spokes, forged for the warrior who demands consistent hydration and absolute isolation. Accessible via **The Sovereign Baseline (SSH)** with a single, unyielding identity.
 
-**🛡️ The Sovereign Record:** The default branch for this Forge is `develop` (The Anvil). For the stable, certified **Sovereign Baseline**, ensure you clone or switch to the `main` branch.
+**🛡️ The Sovereign Record:** The default branch for this Forge is `develop` (**The Anvil**). For the stable, certified **Sovereign Baseline** (**Production**), ensure you clone or switch to the `main` branch.
 
 **The Language of the Tribe:** Strictly **ZSH 5.0+**. No bash-isms, no shortcuts. [See Requirements](docs/requirements.md)
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -70,7 +70,7 @@ To walk the Way on Windows, you must build a sanctuary that speaks the **Languag
 
 ### Final Step: Clone & Init
 
-**🛡️ The Sovereign Record:** The default branch for this repository is `develop`. For the stable, certified **Sovereign Baseline**, ensure you clone using the `-b main` flag as shown below.
+**🛡️ The Sovereign Record:** The default branch for this repository is `develop` (**The Anvil**). For the stable, certified **Sovereign Baseline** (**Production**), ensure you clone using the `-b main` flag as shown below.
 
 Once the pillars are active, open your **Zsh** terminal and run:
 

--- a/VDE_INSTALL.md
+++ b/VDE_INSTALL.md
@@ -35,11 +35,12 @@ The VDE Hub uses the **Sovereign Baseline** to connect you to your Spokes.
 ## 2. Installation Ritual (Step-by-Step)
 
 ### Step 1: Clone the Beskar Hub
-**🛡️ The Sovereign Record:** The default branch for this repository is `develop`. For the stable, certified **Sovereign Baseline**, ensure you clone using the `-b main` flag as shown below.
+**🛡️ The Sovereign Record:** The default branch for this repository is `develop` (The Anvil). For the stable, certified **Sovereign Baseline** (Production), ensure you clone using the `-b main` flag as shown below.
 
 Open your terminal (Zsh) and clone the VDE repository.
 
 ```zsh
+# Clone the stable Production branch (Sovereign Baseline)
 git clone -b main https://github.com/dderyldowney/vde-system.git ~/vde
 cd ~/vde
 ```

--- a/VDE_PROTOCOL.md
+++ b/VDE_PROTOCOL.md
@@ -28,10 +28,11 @@ This project uses a custom orchestration layer. Direct Docker commands are stric
 
 The VDE repository strictly enforces a Sovereign Branching Strategy to maintain the purity of the Baseline:
 
-1. **`main` (The Sovereign Baseline):** This is the stable, "production" branch. It represents the certified, immutable releases of the Forge.
-2. **`develop` (The Anvil):** This is the primary integration branch for all ongoing development.
-3. **Feature Branches (The Strike):** All design, creation, modification, or remediation work MUST be performed on a feature-named branch (e.g., `feat/new-vm-type`, `fix/ssh-bridge`) branching **off of `develop`**.
-4. **The Merge & Deletion:** Once a feature branch survives the Trial of the Gauntlet (testing) and the code is formally **accepted**, it is merged back into `develop`. Immediately following a successful merge, the feature branch **MUST be deleted** to keep the Forge lean and prevent history corruption.
+1. **`main` (Production):** This is the stable production branch. It represents the certified, immutable **Sovereign Baseline** of the Forge.
+2. **`develop` (The Anvil):** This is the primary integration branch for all ongoing development. It is the **Default Branch** for repository operations to enable automated issue closure.
+3. **Semantic Targeting:** The Forge uses semantic roles (`VDE_PRODUCTION_BRANCH`, `VDE_ANVIL_BRANCH`) codified in `lib/vde-constants` to ensure portability.
+4. **Feature Branches (The Strike):** All design, creation, modification, or remediation work MUST be performed on a feature-named branch (e.g., `feat/new-vm-type`, `fix/ssh-bridge`) branching **off of the Anvil (`develop`)**.
+5. **The Merge & Deletion:** Once a feature branch survives the Trial of the Gauntlet (testing) and the code is formally **accepted**, it is merged back into the Anvil (`develop`). Immediately following a successful merge, the feature branch **MUST be deleted** to keep the Forge lean and prevent history corruption.
 
 ---
 

--- a/bin/vde-sync-version
+++ b/bin/vde-sync-version
@@ -170,6 +170,10 @@ Certified verification of the four pillars:
 3. **Docker**: The World-Forge
 4. **SSH**: The Transversal Bridge
 
+## 🛡️ Sovereign Alignment
+- **Production Branch**: \`${VDE_PRODUCTION_BRANCH:-main}\` (Stable Baseline)
+- **Anvil Branch**: \`${VDE_ANVIL_BRANCH:-develop}\` (Active Forge)
+
 ---
 **Certification**: ${BDD_STEPS:-0} BDD Steps, ${BDD_SCENARIOS:-0} Scenarios, ${UNIT_TESTS:-0} Unit Tests, 100% PASS.
 **Dual Audit Loop**: 🟢 CODE AUDIT PASSED | 🟢 SECURITY AUDIT PASSED

--- a/docs/VDE-SPEC.md
+++ b/docs/VDE-SPEC.md
@@ -44,9 +44,10 @@ When a Sovereign Baseline release is cut, the following documents MUST move as a
 ## 6. The Sovereign Branching Strategy
 
 The Forge strictly enforces the following Git lifecycle to maintain the purity of the Baseline:
-1.  **`main` (The Sovereign Baseline)**: The stable production branch. Represents immutable, certified releases. Only accepts merges from `develop` via a Release PR.
-2.  **`develop` (The Anvil)**: The primary integration branch where the Beskar is forged. Only accepts merges from feature branches via a Mission PR.
-3.  **Feature Branches (The Strike)**: All work MUST occur on a feature-named branch (e.g., `feat/name`) branching off the Anvil (`develop`).
+1.  **`main` (Production)**: The stable production branch. Represents the immutable, certified **Sovereign Baseline**. Only accepts merges from the Anvil via a Release PR.
+2.  **`develop` (The Anvil)**: The primary integration branch where the Beskar is forged. This is the **Default Branch** for all repository operations to enable native GitHub automation.
+3.  **Semantic Targeting**: Core scripts and libraries MUST reference branches by their semantic roles (`VDE_PRODUCTION_BRANCH`, `VDE_ANVIL_BRANCH`) to ensure portability and role alignment.
+4.  **Feature Branches (The Strike)**: All work MUST occur on a feature-named branch (e.g., `feat/name`) branching off the Anvil (`develop`).
 4.  **The Ritual of the Signet and the Chronicle**: 
     - **The Signet (Issue)**: Every strike MUST begin with a Signet. The armorer-architect MUST use the authorized tool `gh issue create` to record the mission upon ignition.
     - **The Chronicle (PR)**: Every strike MUST end with a Chronicle. The armorer-architect MUST use the authorized tool `gh pr create` to submit the forged work for the Code Review mandate. The Chronicle MUST serve as the final "**Archive of the Strike**," explicitly linking the Signet ID, the PR ID, and the exact sequence of Commit SHAs.

--- a/lib/vde-constants
+++ b/lib/vde-constants
@@ -58,6 +58,16 @@ VDE_ERR_CACHE_INVALID=11
 VDE_ERR_SYNC_DRIFT=13
 
 # =============================================================================
+# BRANCH CONFIGURATION
+# =============================================================================
+# VDE uses semantic branch naming to ensure portability.
+# VDE_PRODUCTION_BRANCH: The stable, certified Sovereign Baseline (default: main)
+# VDE_ANVIL_BRANCH: The active integration and development branch (default: develop)
+
+VDE_PRODUCTION_BRANCH="${VDE_PRODUCTION_BRANCH:-main}"
+VDE_ANVIL_BRANCH="${VDE_ANVIL_BRANCH:-develop}"
+
+# =============================================================================
 # PORT CONFIGURATION
 # =============================================================================
 # VDE uses specific port ranges to avoid conflicts with common services.
@@ -296,6 +306,7 @@ if [[ "${VDE_TEST_MODE:-0}" -ne 1 ]] ; then
              VDE_RETRY_MAX_DELAY VDE_STALE_LOCK_AGE VDE_LOCK_CHECK_INTERVAL \
              VDE_LOG_RETENTION_DAYS VDE_MAX_LOG_SIZE VDE_DOCKER_NETWORK VDE_TEST_NETWORK \
              VDE_COMPOSE_PROJECT_PREFIX VDE_CONTAINER_PREFIX \
+             VDE_PRODUCTION_BRANCH VDE_ANVIL_BRANCH \
              VDE_SSH_USER VDE_SSH_KEY_PREFERENCE VDE_HOME_DIR VDE_SSH_DIR \
              VDE_SSH_CONFIG VDE_SSH_KNOWN_HOSTS VDE_SSH_IDENTITY VDE_SSH_IDENTITY_PUB \
              VDE_SSH_AGENT_ENV \

--- a/lib/vde-errors
+++ b/lib/vde-errors
@@ -46,7 +46,7 @@ VDE_ERRORS_VERBOSE="${VDE_ERRORS_VERBOSE:-0}"
 export VDE_ERRORS_VERBOSE
 
 # Documentation base URL
-VDE_ERRORS_DOC_URL="${VDE_ERRORS_DOC_URL:-https://github.com/dderyldowney/VDE/blob/main/docs}"
+VDE_ERRORS_DOC_URL="${VDE_ERRORS_DOC_URL:-https://github.com/dderyldowney/vde-system/blob/${VDE_PRODUCTION_BRANCH:-main}/docs}"
 
 # Show remediation steps by default
 VDE_ERRORS_SHOW_SOLUTION="${VDE_ERRORS_SHOW_SOLUTION:-1}"


### PR DESCRIPTION
Closes #21

## Archive of the Strike
This Chronicle records the codification of semantic branch roles (**Production** for `main` and **The Anvil** for `develop`) and the implementation of centralized constants to ensure structural portability.

## Heartbeat & Proof of Life
### Empirical Certification
All 71 steps of the VM lifecycle passed with 100% Green status.

```text
1 feature passed, 0 failed, 0 skipped
6 scenarios passed, 0 failed, 0 skipped
71 steps passed, 0 failed, 0 skipped
Took 3min 34.698s
```

### Deliverables
- [x] Added `VDE_PRODUCTION_BRANCH` and `VDE_ANVIL_BRANCH` to `lib/vde-constants`.
- [x] Synchronized all documentation (`README.md`, `VDE_INSTALL.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`, `VDE_PROTOCOL.md`).
- [x] Updated agent instructions (`AGENTS.md`, `.gemini/instructions.md`, `MEMORY.md`).
- [x] Refined release record generation in `bin/vde-sync-version`.

This strike is certified 100% compliant with the Sovereign Baseline 1.3.1.

## Summary by Sourcery

Codify semantic roles for the main and develop branches and centralize their usage across core scripts and documentation.

New Features:
- Introduce semantic branch role constants (production and Anvil) for use across the core system.

Enhancements:
- Align contributor and agent workflows on The Anvil (`develop`) as the default integration branch with main as the production baseline.
- Update branching, PR, and cloning guidance in user- and contributor-facing docs to reflect semantic branch targeting and default-branch behavior.
- Refine version and release record tooling to rely on centralized branch role constants for improved portability.

Documentation:
- Revise README, install guide, user guide, protocol/spec, contributing guide, memory, and agent instructions to define Production and The Anvil roles and clarify default-branch semantics.