### PR TITLE
enforce(process): mandate Strike Protocol gates in CLAUDE.md and .gemini/instructions.md

### DIFF
--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -90,6 +90,10 @@ Failure of any ritual constitutes a **Protocol Blockade**.
     * Feature branches are merged into the Anvil (`develop`) ONLY upon acceptance and MUST be deleted immediately after.
     * **Permanence**: The Production (`main`) and Anvil (`develop`) branches are the foundational pillars of the Record; they are never removed.
     * The agent is PRE-AUTHORIZED to use `gh issue create` and `gh pr create` to initialize missions and record the Signet of Intent and submit the Chronicle. The agent is also authorized for read access (`gh issue view/list`, `gh pr view/list`) to initialize, monitor, and submit missions.
+    * **PRE-IMPLEMENTATION GATE (ABSOLUTE)**: Before writing a single line of implementation code or running any `git commit` on `develop`, the agent MUST have completed ALL of the following — no exceptions, no shortcuts, no "I'll retro-fix it later":
+        1. `gh issue create` — Signet OPEN with Issue number confirmed
+        2. `git checkout -b <type>/<slug>` from `develop` — feature branch ACTIVE
+        If either gate is missing, the agent MUST STOP, complete the gate, then proceed. Committing implementation directly to `develop` is a Creed violation that requires immediate retro-remediation and a process violation report to the User.
 * **Q. The Authority of the Record**: Only the Alor (Orchestrator) and the User possess the authority to alter the Chronicle. Sub-agents are strictly forbidden from making autonomous commits. All commits performed by sub-agents MUST be under the direct and serialized control of the Orchestrator.
 * **R. The Clan Leader Authority (PR & Merge Gate)**:
     * The agent MAY make regular local commits on the active feature branch as needed to preserve a clear and incremental history.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+Read and apply @AGENTS.md
+
+## STRIKE PROTOCOL — MANDATORY. NO EXCEPTIONS.
+
+Every unit of work (a "Strike") MUST follow this sequence. There is no bypass except an explicit written instruction from the User in the current session:
+
+1. **SIGNET**: `gh issue create` — open a GitHub Issue describing the work BEFORE any implementation begins
+2. **BRANCH**: `git checkout -b <type>/<slug>` from `develop` — create a feature branch tied to the Issue
+3. **IMPLEMENT**: All code changes on the feature branch only. NEVER commit implementation to `develop` directly.
+4. **CHRONICLE**: `gh pr create` — open a PR from the feature branch targeting `develop`
+5. **PRE-MERGE HALT**: Stop. Present the PR URL to the User. Wait for explicit written approval before merging.
+6. **MERGE**: Only after User written approval. Use `gh pr merge`.
+
+Committing implementation directly to `develop` is a Creed violation. If you catch yourself writing code or running `git commit` on `develop` without a prior `gh issue create` and feature branch, STOP immediately and retro-fix the process before continuing.


### PR DESCRIPTION
## Summary

- Closes #28
- Adds a hard **STRIKE PROTOCOL** section to `CLAUDE.md` — a 6-step mandatory sequence with no bypass except explicit written User instruction in the active session
- Adds a **PRE-IMPLEMENTATION GATE (ABSOLUTE)** subsection to Rule P in `.gemini/instructions.md` — two gates (Signet open + feature branch active) that must both be satisfied before any implementation code is written or any `git commit` on `develop` runs

## Motivation

Process violation in commit `d35a328` — implementation committed directly to `develop` without an Issue or feature branch. Retroactively documented via Issue #26 and PR #27. This Strike closes the enforcement gap so the path cannot be skipped without deliberate User override.

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | New STRIKE PROTOCOL section — 6 mandatory steps, no bypass |
| `.gemini/instructions.md` | Rule P: PRE-IMPLEMENTATION GATE with two hard pre-conditions |

## Test plan

- [x] CLAUDE.md Strike Protocol section present and readable as first non-include content
- [x] Rule P in .gemini/instructions.md contains PRE-IMPLEMENTATION GATE language
- [x] Both gates (Issue + feature branch) named explicitly with "Creed violation" consequence for bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document a mandatory strike-based development workflow and enforce pre-implementation gating before work on the develop branch can begin.

Enhancements:
- Add a mandatory STRIKE PROTOCOL workflow to CLAUDE.md covering issue creation, branching, implementation, PR creation, approval, and merge steps.
- Strengthen Rule P in .gemini/instructions.md with an absolute pre-implementation gate requiring both an open issue and an active feature branch before any implementation or commits on develop.