### PR TITLE
fix(core): correct uninstall-vm-type help text to reflect SSH config removal

### DIFF
--- a/bin/uninstall-vm-type
+++ b/bin/uninstall-vm-type
@@ -11,8 +11,10 @@
 # The following are INVIOLATE and PRESERVED:
 # - configs/docker/<type>/ directory (docker-compose.yml)
 # - env-files/<type>.env (environment configuration)
-# - SSH config entries (static port assignments)
 # - projects/<type>/ directory (your code)
+#
+# NOTE: SSH config entries for dynamically-added VMs are removed on uninstall.
+# Statically-configured entries (managed by generate-all-configs) are unaffected.
 #
 # Usage: uninstall-vm-type <vm_type> [--dry-run] [--skip-confirm]
 #===============================================================================
@@ -330,8 +332,10 @@ main() {
         echo "The following are INVIOLATE and PRESERVED:"
         echo "  - configs/docker/<vm_type>/ directory"
         echo "  - env-files/<vm_type>.env file"
-        echo "  - SSH config entries"
         echo "  - projects/<vm_type>/ directory"
+        echo ""
+        echo "NOTE: SSH config entries for dynamically-added VMs are removed on uninstall."
+        echo "      Statically-configured entries (generate-all-configs) are unaffected."
         echo ""
         echo "Options:"
         echo "  --dry-run         Show what would be done without making changes"
@@ -356,8 +360,10 @@ main() {
         echo "The following are INVIOLATE and PRESERVED:"
         echo "  - configs/docker/<vm_type>/ directory"
         echo "  - env-files/<vm_type>.env file"
-        echo "  - SSH config entries"
         echo "  - projects/<vm_type>/ directory"
+        echo ""
+        echo "NOTE: SSH config entries for dynamically-added VMs are removed on uninstall."
+        echo "      Statically-configured entries (generate-all-configs) are unaffected."
         echo ""
         echo "Options:"
         echo "  --dry-run         Show what would be done without making changes"
@@ -433,8 +439,10 @@ main() {
     echo "The following are INVIOLATE and PRESERVED:"
     echo "  - configs/docker/${CANONICAL_NAME}/ directory"
     echo "  - env-files/${CANONICAL_NAME}.env file"
-    echo "  - SSH config entries"
     echo "  - projects/${CANONICAL_NAME}/ directory"
+    echo ""
+    echo "NOTE: SSH config entries for dynamically-added VMs are removed on uninstall."
+    echo "      Statically-configured entries (generate-all-configs) are unaffected."
     echo ""
 
     if [[ "${DRY_RUN}" = "true" ]]; then


### PR DESCRIPTION
## Summary

- Closes #30
- Resolves BLOCKER from code review of PR #27
- `bin/uninstall-vm-type` file header and all three user-facing help blocks previously declared SSH config entries as **INVIOLATE and PRESERVED**. Since `d35a328`, `remove_ssh_entries()` actively removes dynamically-added `Host` blocks on uninstall. This was a broken behavioral contract.

## Changes

All four locations in `bin/uninstall-vm-type` updated:
- File header comment (lines 11-16)
- `--help` flag output
- No-args usage output
- Runtime confirmation banner

Each now carries a NOTE clarifying that entries for **dynamically-added VMs are removed** on uninstall, while **statically-configured entries** (managed by `generate-all-configs`) remain unaffected.

## Test plan

- [x] `bin/vde uninstall --help` no longer claims SSH entries are preserved
- [x] Runtime confirmation banner accurate
- [x] Full suite: 35/36 pass (pre-existing SIGINT regression on `develop`, unrelated to this change — fix pending merge of `fix/test-regressions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update uninstall-vm-type help, usage, and confirmation text to note that dynamically-added SSH host entries are removed on uninstall while static entries remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in uninstall command messaging with a note distinguishing how SSH config entries are handled for dynamically-added versus statically-configured VMs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->