### PR TITLE
fix(core): align SSH configuration with Sovereign Baseline 1.3.7

### DIFF
--- a/bin/generate-all-configs
+++ b/bin/generate-all-configs
@@ -60,12 +60,13 @@ get_service_port() {
 generate_ssh_config() {
   local ssh_config="${VDE_ROOT_DIR}/configs/ssh/config"
   local timestamp=$(date)
+  local current_version=$(vde_get_version)
   
   mkdir -p "$(dirname "${ssh_config}")"
   
   cat > "${ssh_config}" <<EOF
 # VDE (Virtual Development Environment) SSH Configuration
-# Sovereign Baseline: 1.3.1
+# Sovereign Baseline: ${current_version}
 # Generated on ${timestamp}
 #
 # This file contains SSH config entries for all known language and service VMs.

--- a/bin/vde-sync-version
+++ b/bin/vde-sync-version
@@ -41,7 +41,7 @@ vde_log_info "Synchronizing Sovereign Artifact Set..." "forge"
 # 4.1 Strike docs/VDE-SPEC.md (The Beskar Source)
 vde_sed_inplace "s/Version: [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/Version: ${NEW_VER}/" "${VDE_ROOT_DIR}/docs/VDE-SPEC.md"
 vde_sed_inplace "s/ARCHITECTURE [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)? .*/ARCHITECTURE ${NEW_VER} (The Sovereign Baseline)/" "${VDE_ROOT_DIR}/docs/VDE-SPEC.md"
-vde_sed_inplace "s/^# VDE-SPEC [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/# VDE-SPEC ${NEW_VER} (The Sovereign Evolution)/" "${VDE_ROOT_DIR}/docs/VDE-SPEC.md"
+vde_sed_inplace "s/^# VDE-SPEC [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?(\s+\(.*\))?/# VDE-SPEC ${NEW_VER} (The Sovereign Evolution)/" "${VDE_ROOT_DIR}/docs/VDE-SPEC.md"
 vde_log_success "Aligned docs/VDE-SPEC.md" "forge"
 
 # 4.2 Strike docs/ARCHITECTURE.md
@@ -111,6 +111,13 @@ vde_log_success "Aligned .gemini_security/REMEDIATION_PLAN.md" "forge"
 # 16. Strike VDE_PROTOCOL.md
 vde_sed_inplace "s/# VDE Project Protocol \([0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?\)/# VDE Project Protocol (${NEW_VER})/" "${VDE_ROOT_DIR}/VDE_PROTOCOL.md"
 vde_log_success "Aligned VDE_PROTOCOL.md" "forge"
+
+# 16.1 Strike Miscellaneous Library and Tool Records
+vde_sed_inplace "s/Sovereign Baseline [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/Sovereign Baseline ${NEW_VER}/g" "${VDE_ROOT_DIR}/bin/vde-tactical-sweep.zsh"
+vde_sed_inplace "s/Sovereign Baseline: [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/Sovereign Baseline: ${NEW_VER}/g" "${VDE_ROOT_DIR}/lib/vde-ssh"
+vde_sed_inplace "s/\[v\][0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/\[v\]${NEW_VER}/" "${VDE_ROOT_DIR}/lib/vde-core"
+vde_sed_inplace "s/Sovereign Baseline: [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/Sovereign Baseline: ${NEW_VER}/" "${VDE_ROOT_DIR}/configs/ssh/config"
+vde_log_success "Aligned miscellaneous tools and libraries" "forge"
 
 # 17. Strike BDD features and steps
 vde_sed_inplace "s/synchronized to version [0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?/synchronized to version ${NEW_VER}/" "${VDE_ROOT_DIR}/tests/features/core-infrastructure/proof-of-life-the-contract.feature"

--- a/bin/vde-tactical-sweep.zsh
+++ b/bin/vde-tactical-sweep.zsh
@@ -2,7 +2,7 @@
 #===============================================================================
 # vde-tactical-sweep.zsh - Comprehensive Forge Cleanup Tool
 #
-# Part of the Sovereign Baseline 1.3.1.
+# Part of the Sovereign Baseline 1.3.7.
 # Mandate: Zero-Host Dependency & Zero-Ghost Persistence.
 # Forged in Beskar.
 #===============================================================================

--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
-# Sovereign Baseline: 1.3.1
-# Generated on Wed Apr 15 21:24:07 EDT 2026
+# Sovereign Baseline: 1.3.7
+# Generated on Wed Apr 15 22:33:10 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:

--- a/lib/vde-core
+++ b/lib/vde-core
@@ -31,7 +31,7 @@ vde_get_version() {
     local spec_file="${root}/docs/VDE-SPEC.md"
 
     if [[ -f "${spec_file}" ]]; then
-        # Extracts version from "# VDE-SPEC [v]1.3.1-sp0 (The Sovereign Baseline)"
+        # Extracts version from "# VDE-SPEC [v]1.3.7 (The Sovereign Baseline)"
         # Supports optional 'v' prefix and SemVer extensions like -spN
         grep -m1 '^# VDE-SPEC ' "${spec_file}" | sed -E 's/^# VDE-SPEC v?([0-9]+\.[0-9]+\.[0-9]+(-sp[0-9]+)?).*/\1/' | tr -d '[:space:]'
     else

--- a/lib/vde-ssh
+++ b/lib/vde-ssh
@@ -711,7 +711,7 @@ generate_vm_ssh_config() {
     # Truncate existing config and write header — this is a full regeneration, not an incremental merge
     cat <<EOF > "${VDE_SSH_CONFIG}"
 # VDE (Virtual Development Environment) SSH Configuration
-# Sovereign Baseline: 1.3.1
+# Sovereign Baseline: 1.3.7
 # Generated on $(date)
 #
 # This file contains SSH config entries for all known language and service VMs.

--- a/tests/features/core-infrastructure/ssh-config-version.feature
+++ b/tests/features/core-infrastructure/ssh-config-version.feature
@@ -1,0 +1,9 @@
+@system-spine
+Feature: SSH Configuration Version Alignment
+  As an Alor of the VDE
+  I require the SSH configuration to match the Sovereign Baseline
+  So that the Forge remains synchronized
+
+  Scenario: Verify SSH Configuration Version
+    Given the Hub is synchronized to version 1.3.7
+    Then the file "configs/ssh/config" should contain "Sovereign Baseline: 1.3.7"


### PR DESCRIPTION
This mission aligns configs/ssh/config and related tools with 1.3.7, refactors the generator for dynamic sourcing, and hardens the synchronization ritual.

Closes #64

## Summary by Sourcery

Align SSH configuration and supporting tooling with Sovereign Baseline version 1.3.7 and enforce this alignment via automated tests.

Enhancements:
- Update core scripts and SSH-related tooling to reference and synchronize against Sovereign Baseline version 1.3.7.

Tests:
- Add a feature test to verify that the SSH configuration file declares Sovereign Baseline version 1.3.7.