### PR TITLE
fix(ssh): synchronize Sovereign Baseline timestamp in config

### DIFF
--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.0
-# Generated on Thu Apr 16 20:45:12 EDT 2026
+# Generated on Thu Apr 16 22:21:46 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:


### PR DESCRIPTION
Synchronizes the generated timestamp in configs/ssh/config after the Session 1.4.0 initialization ritual.\n\nCloses #102

## Summary by Sourcery

Bug Fixes:
- Align the Sovereign Baseline timestamp in configs/ssh/config to prevent configuration drift after initialization.