### PR TITLE
docs: declare VDE 1.4.1 as the unique Sovereign Baseline

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,10 +1,11 @@
 # PROJECT STATUS - VDE 1.4.1 (The Sovereign Baseline)
 
-**CURRENT STATE: 100% GREEN (SOVEREIGN BASELINE CERTIFIED)**
-**DATE:** 2026-04-15
+**CURRENT STATE: 100% GREEN (THE UNIQUE SOVEREIGN BASELINE)**
+**DATE:** 2026-04-18
+**RELEASE:** [VDE 1.4.1](https://github.com/dderyldowney/vde-system/releases/tag/1.4.1)
 
 ## EXECUTIVE SUMMARY
-1.4.1 is officially declared the functional baseline for the VDE project. All technical debt from previous versions has been remediated or archived.
+1.4.1 is hereby declared the **New Sovereign Baseline** across the entire platform. This version represents the absolute functional and security standard for the Forge. All previous versions (1.3.x and earlier) are preserved for historical archival use only and are no longer supported for active Forge operations.
 
 ### 1. CORE MILESTONES COMPLETED
 - [x] **System Spine Tetrad**: Empirical verification of Zsh, Git, Docker, and SSH Pillars (1.4.1).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,8 +5,9 @@ This file tracks the evolution of the Virtual Development Environment. For detai
 ## 🟢 Latest Sovereign Baseline: [1.4.1](./docs/releases/1.4.1.md) (2026-04-17)
 
 ---
-## 📦 Release History
+## 📦 Historical Archive (Inactive)
 
-- [1.4.1] (./docs/releases/1.4.1.md)
+*The following versions are preserved for historical record only and are superseded by the 1.4.1 Sovereign Baseline.*
+
 - [1.4.0] (./docs/releases/1.4.0.md)
 - [1.3.7] (./docs/releases/1.3.7.md)


### PR DESCRIPTION
## Objective
Establish VDE 1.4.1 as the unique, global Sovereign Baseline.

## What Was Wrong
The project history lacked a formal declaration of 1.4.1 as the sole active standard, leaving historical versions as potential sources of confusion.

## The Fix
Updated the authoritative status records to mark 1.4.1 as the unique baseline and move all previous versions to a historical archive.

## Verification
- Records verified and synchronized.
- Proof of Life certified.

Closes #123

## Summary by Sourcery

Declare VDE 1.4.1 as the single active Sovereign Baseline and mark all prior versions as historical only.

Documentation:
- Update project status documentation to state that VDE 1.4.1 is the unique Sovereign Baseline and link to its release.
- Reclassify earlier VDE releases in the release notes as an inactive historical archive superseded by 1.4.1.