### PR TITLE
law: codify the Pre-Release Declaration Mandate

### DIFF
--- a/docs/VDE-SPEC.md
+++ b/docs/VDE-SPEC.md
@@ -56,6 +56,7 @@ Automated orchestration ensures absolute traceability:
 - **Reporting Minimums (MANDATORY)**:
     - **Issue Bodies**: MUST include full documentation of what is wrong (the "Sovereign Reason" for the Issue).
     - **PR Bodies**: MUST include (1) What was wrong, (2) What the fix was, and (3) A complete list of Files involved. This is the absolute minimum acceptable information.
+- **The Pre-Release Declaration Mandate**: BEFORE merging any release Chronicle into Production (`main`), a dedicated Declaration Ritual MUST be performed. This ritual updates `PROJECT_STATUS.md` to declare the new version as the unique baseline and relegates previous entries in `RELEASE_NOTES.md` to the archive. The release merge cannot proceed until this declaration is recorded in the Anvil.
 
 ## 6. Security & Infrastructure Bridge
 


### PR DESCRIPTION
## Objective
Establish the mandatory sequence for release rituals to ensure Production integrity.

## What Was Wrong
The previous release protocol allowed merging into `main` before the new baseline was formally declared in the project's status and archive records.

## The Fix
Codified Rule O and Section 5 mandates requiring a dedicated **Declaration Ritual** on `develop` as a hard prerequisite for any merge into `main`.

## Files Involved
- docs/VDE-SPEC.md
- gemini.md

## Verification
- Mandates codified and recorded in project memory.
- Proof of Life Certified.

Closes #125

## Summary by Sourcery

Documentation:
- Document the Pre-Release Declaration Mandate, requiring a declaration ritual on the release branch that updates project status and archives prior release notes before any merge to main.