### PR TITLE
docs: overhaul WHY_USE_VDE.md for absolute 1.4.1 accuracy

### DIFF
--- a/docs/WHY_USE_VDE.md
+++ b/docs/WHY_USE_VDE.md
@@ -34,13 +34,13 @@ We've *all* been there, and friend, it is *not* fun. You spend more time setting
 
 **VDE (Virtual Development Environment)** gives you isolated, ready-to-use containers for *any* programming language or service you can dream of.
 
-Think of it like having a magical workshop with every tool you could ever want — each tool in its own dedicated workspace, always ready, always clean, never interfering with anything else. And the best part? You don't even have to clean up afterward! ✨
+Think of it like having a magical workshop with every tool you could ever want — each tool in its own dedicated workspace, always ready, always clean, never interfering with anything else. And the best part? Your code is safe on your own computer! ✨
 
 ---
 
-## What Do I Need? (Spoiler: The Unyielding Tetrad!) 🎒
+## What Do I Need? (The Unyielding Tetrad) 🎒
 
-You only need **four things** (The Unyielding Tetrad) to participate in the Forge:
+You only need **four things** (The Unyielding Tetrad) installed on your computer:
 
 | What | Why | Already Have It? |
 |------|-----|------------------|
@@ -53,18 +53,6 @@ You only need **four things** (The Unyielding Tetrad) to participate in the Forg
 
 ### 🪟 Windows Users: The WSL2 Mandate
 Windows users can perfectly unify their environment with Linux and MacOS by using **WSL2 (Windows Subsystem for Linux)**. Once WSL2 is active, you can install the full Tetrad and walk the same path as any other warrior.
-
-### Don't Have One of Those? No Stress! 😌
-
-The [**User Guide**](./USER_GUIDE.md) includes **beginner-friendly, no-knowledge-required tutorials** for:
-
-- Installing Docker Desktop (Mac, Windows, Linux)
-- Installing Git
-- Checking which shell you're using (zsh)
-
-Even if you've never used Terminal before, we've got you covered.
-
-**We literally walk you through clicking buttons.** No assumptions about what you know. No judgment. Just helpful guidance every step of the way.
 
 ---
 
@@ -80,18 +68,11 @@ vde
 
 That's it. One command to remember. No memorizing a dozen different scripts. Just `vde`. Easy!
 
-**Need to see what's available?**
-```zsh
-vde help
-```
-
-This shows you all available actions: creating VMs, starting/stopping, listing, checking status, and more.
-
 ---
 
 ## Getting Started: It's This Easy 🚀
 
-Ready to have your mind blown (in the best way)? Here's all it takes to get started with Python:
+Ready to have your mind blown? Here's all it takes to get started:
 
 ```zsh
 # Step 1: Ignite the Forge (only once!)
@@ -105,287 +86,77 @@ vde start python
 vde enter python
 ```
 
-**Four steps.** That's all.
+**And now...** 🎊 You have a fully-functional Python environment with its own isolated workspace. 
 
-**And now...** 🎊 You have a fully-functional Python development environment with:
-- Python 3 and pip installed
-- Its own isolated workspace
-- SSH access with your keys
-- Connection to shared services (PostgreSQL, Redis, MongoDB, etc.)
-- Zero conflicts with anything else on your computer
-
-**You just became a Python developer. How cool is that?**
-
----
-
-## Want Rust Too? Go Ahead! 🦀
-
-```zsh
-vde create rust
-vde start rust
-vde enter rust
-```
-
-Boom! Now you have Python **and** Rust running side-by-side. No conflicts. No version wars. They don't even know each other exist (unless you want them to). You're basically a polyglot programmer now! 😎
+**Wait, where is my code?** 📂
+When you are inside a Spoke (like Python), you work in `/home/devuser/workspace`. This is a **Reflection** of the `projects/` directory inside your VDE folder on your computer. Anything you save there is already saved on your laptop! No moving files, no manual sync. It's just there.
 
 ---
 
 ## What Can I Run? (Spoiler: Everything!) 🌍
 
-VDE supports **23 programming languages** out of the box — yes, seriously:
+VDE supports **23 programming languages** and **8 shared services** out of the box:
 
-| Category | Languages |
+| Category | Highlights |
 |----------|-----------|
-| **Systems** | C, C++, Assembly, Rust, Zig |
-| **Web** | JavaScript, PHP, Python, Ruby |
-| **Enterprise** | Java, Kotlin, C#, Scala |
-| **Data Science** | Python, R, JupyterLab |
-| **Modern** | Go, Elixir, Haskell, Swift |
-| **Mobile** | Flutter (Dart) |
-| **Scripting** | Lua, Bash (internal use) |
+| **Languages** | Python, Rust, Go, JavaScript, C++, Zig, Flutter, Java, and more! |
+| **Services** | PostgreSQL, MySQL, Redis, MongoDB, Nginx, RabbitMQ, and more! |
 
-Plus **8 shared services** ready to go:
-- PostgreSQL, MySQL (databases)
-- Redis (caching)
-- MongoDB (document store)
-- Nginx (web server)
-- RabbitMQ, CouchDB (messaging)
-- JupyterLab (data suite)
-
-All pre-configured. All ready to connect. All waiting for you. Your playground awaits! 🎠
+All pre-configured. All ready to connect. All waiting for you.
 
 ---
 
 ## The "Magic" Part: VMs Talking to VMs ✨
 
-This is where VDE gets *really* cool. Like, actually magic.
-
-Imagine you're working in your Python container and you need to test something against the PostgreSQL database. You don't need to exit, open a new terminal, or mess with connection strings:
+Imagine you're working in your Python container and you need to test something against a database. You don't need to exit or mess with connection strings:
 
 ```zsh
-# From inside your Python VM
+# From inside your Python Spoke
 vde_ssh vde-postgres psql -U devuser
 ```
 
-That's it. You're now in PostgreSQL. Using **your** SSH keys. Without any setup. Magic!
-
-Your VMs can SSH to each other. Your VMs can SSH to external services (like GitHub) using **your** credentials. Your VMs can even run commands on **your** host computer.
-
-And the best part? Your private keys *never leave your computer*. They're safely forwarded through SSH agent magic. (We'll explain the details later — just know it's secure, and you're protected!)
-
----
-
-## Real-World Example: Your Full-Stack Playground 🏗️
-
-Let's say you want to build a web app with:
-- A Python backend
-- A JavaScript frontend
-- A PostgreSQL database
-- Redis for caching
-
-Here's your workflow:
-
-```zsh
-# Create everything
-vde create python js postgres redis
-
-# Start everything
-vde start python js postgres redis
-
-# Connect to your Python backend
-vde enter python
-cd ~/workspace/my-app
-pip install -r requirements.txt
-python app.py
-```
-
-In another terminal:
-
-```zsh
-# Connect to your JavaScript frontend
-vde enter js
-cd ~/workspace/my-app
-npm install
-npm start
-```
-
-Your Python app talks to `vde-postgres` and `vde-redis` by hostname. No connection strings to remember. No ports to memorize. It just works. *Like magic.* ✨
-
----
-
-## But I Already Have a Development Environment... 🤔
-
-That's great! But consider:
-
-### 🤔 Problem: Learning a New Language
-**Without VDE:** Install language, manage versions, risk breaking your current setup.
-**With VDE:** `vde create elixir` and you're done. Delete it when you're finished. Easy peasy!
-
-### 🤔 Problem: "Works on My Machine"
-**Without VDE:** Endless debugging of environment differences. Frustration for everyone.
-**With VDE:** Everyone runs the exact same containers. Same versions. Same everything. Peace at last! 🕊️
-
-### 🤔 Problem: Testing Against Multiple Versions
-**Without VDE:** Complex version management tools. Headaches galore.
-**With VDE:** Create a VM for Python 3.9 and another for 3.11. Test against both. No sweat!
-
-### 🤔 Problem: Dependency Hell
-**Without VDE:** One project's dependencies break another's. Chaos reigns.
-**With VDE:** Each project lives in isolation. No conflicts. Ever. Pure harmony! 🎶
+Your Spokes can talk to each other and to the outside world using **your** credentials, safely forwarded through the SSH bridge.
 
 ---
 
 ## You're in Control (Even If You Don't Know Docker) 🎮
 
-VDE handles all the Docker complexity for you. You don't need to know:
-- How to write Dockerfiles
-- How to configure networks
-- How to manage volumes
-- How to set up SSH
-
-**VDE does it all.** You just focus on coding and creating awesome things!
-
-But if you *do* know Docker, you'll love that VDE generates clean, readable `docker-compose.yml` files that you can customize to your heart's content. Best of both worlds!
+VDE handles all the Docker complexity for you. You don't need to know how to write Dockerfiles or configure networks. **VDE does it all.** You just focus on coding!
 
 ---
 
-## For the Curious: What's Actually Happening? 🤓
-
-When you run `vde create python`, VDE:
-
-1. Finds an available SSH port (automatically)
-2. Creates a Docker Compose configuration
-3. Sets up your project directory
-4. Adds an SSH config entry (`ssh vde-python` will work)
-5. Starts the SSH agent (if not running)
-6. Loads your SSH keys (or generates a pair if you don't have one)
-7. Gets everything ready for `vde start`
-
-When you run `vde start python`, VDE:
-
-1. Builds a Docker image with your language pre-installed
-2. Creates a container with:
-   - Your code mounted from your computer
-   - SSH access configured
-   - Agent forwarding enabled (for VM-to-VM communication)
-   - A user account (`devuser`) with sudo access
-3. Connects the container to the VDE network (so VMs can talk to each other)
-4. Starts the SSH server
-
-When you `vde enter python`:
-
-1. Your SSH connection goes directly into the container
-2. You land in `/home/devuser/workspace`
-3. Your code is there (it's actually on your computer, mounted in)
-4. Everything you need is ready
-
-**And all of that happens in seconds.** Pretty amazing, right? 🤩
-
----
-
-## So... Why Should You Use VDE? (Great Question!) 🤔
+## So... Why Use VDE? 🤔
 
 ### For Beginners 👶
-- Learn any language without installation nightmares
-- Experiment freely — can't break your actual computer!
-- Focus on coding, not configuring
-- Build confidence without fear of messing things up
+- Learn any language without installation nightmares.
+- Experiment freely — you can't break your actual computer!
 
 ### For Experienced Developers 💼
-- Rapid environment switching
-- Consistent environments across teams
-- Test against multiple language versions
-- Isolate experimental projects
-- Spend more time coding, less time debugging setup
-
-### For Teams 👥
-- Everyone runs the same environment (finally!)
-- New developer onboarding? "Run these three commands."
-- No more "it works on my machine" headaches
-- Shared services (databases) available to everyone
-- Team harmony restored! 🎵
+- Rapid environment switching.
+- Consistent environments across teams — "It works on *everyone's* machine!"
 
 ### For Tinkerers 🔧
-- Try a new language for a weekend (then delete it!)
-- Experiment with weird combinations
-- Learn how Docker containers work (VDE generates readable configs)
-- Satisfy your curiosity without commitment
-
-### For Educators 📚
-- Students all have identical environments
-- No debugging of student laptop configurations
-- Focus on teaching concepts, not troubleshooting
-- More time for what matters: learning and creating!
+- Try a new language for a weekend, then `vde remove` it. No traces left.
 
 ---
 
-## The "Is This For Me?" Checklist ✅
+## What If I Want to Stop Using VDE? 👋
 
-You should use VDE if you answered "yes" to any of these:
+We get it! Sometimes you're done or just want to clean up. VDE is designed to be completely removable with a single ritual.
 
-- [ ] You've ever spent more than an hour setting up a development environment
-- [ ] You've ever said "but it works on my machine" (and meant it 😅)
-- [ ] You want to learn a new language without commitment
-- [ ] You work with multiple programming languages
-- [ ] You've ever broken your environment installing something
-- [ ] You want to try a technology without "polluting" your computer
-- [ ] You want to isolate experimental or learning projects
-- [ ] You want your team to have consistent environments
-
-**If you checked any of these... VDE is for you!** Let's get started!
-
----
-
-## What People Are Saying 💬
-
-*(Okay, we made these up, but they're what users *would* say if they were real)*
-
-> "I went from 'I want to learn Rust' to writing Rust code in 30 seconds. That's not an exaggeration." — *Hypothetical Satisfied User*
-
-> "My team's new developer onboarding went from 2 days of environment setup to 5 minutes. It's ridiculous." — *Imaginary Team Lead*
-
-> "I tried Elixir for a weekend, then deleted the VM. No traces left. Perfect." — *Fictional Language Explorer*
-
-> "I can't believe I used to install PostgreSQL locally. What was I thinking?" — *Retroactively Enlightened Developer*
-
----
-
-## What If I Want to Stop Using VDE? (No Hard Feelings!) 👋
-
-We get it! Sometimes you try something and it's not for you. Or maybe you're just done with a project and want to clean up. No worries at all — VDE is designed to be completely removable.
-
-**Good news: VDE is designed to be completely removable.**
-
-### The Two-Step Farewell 👋
+### The Removal Ritual ☢️
 
 ```zsh
-# 1. Stop any running VMs
-vde stop all
-
-# 2. Delete the VDE directory
-cd ..
-rm -rf VDE/  # or whatever you named the directory
+# Dissolve the entire Forge, images, networks, and configurations
+vde nuke
 ```
 
-**That's it!** No leftover packages. No system changes to undo. No registry keys to clean. The directory is gone, and so is VDE. Clean as a whistle! ✨
+**Manual cleanup (if you prefer):**
+1. Stop all containers: `vde stop all`
+2. Delete the VDE directory.
+3. Delete the isolated SSH vault: `rm -rf ~/.ssh/vde`
 
-Your Docker images will take up some disk space (you can clean those with Docker Desktop if you want), but VDE itself leaves zero trace on your system.
-
-### Wait, Can I Keep My Code? 🤔
-
-**Absolutely!** Your code is in the `projects/` directory inside the VDE folder. Before deleting VDE:
-
-```zsh
-# Copy your projects somewhere safe
-cp -r VDE/projects ~/my-projects-backup
-
-# Or move individual projects
-mv VDE/projects/python/my-app ~/my-app
-```
-
-Then delete VDE, and your projects live on. Safe and sound!
-
-**VDE is just a tool for your development — not a prison for your code.** Your creations belong to you, always! 💝
+**That's it!** No leftover packages. No system changes to undo. Clean as a whistle! ✨
 
 ---
 
@@ -394,9 +165,9 @@ Then delete VDE, and your projects live on. Safe and sound!
 **Your first VDE is four steps away:**
 
 ```zsh
-cd ~/dev  # or wherever you cloned this repo
+cd VDE
 vde init
-vde create python  # or any language you want!
+vde create python
 vde start python
 vde enter python
 ```
@@ -405,42 +176,6 @@ vde enter python
 
 ---
 
-## Want Learn More? (We've Got You Covered!) 📚
-
-- [**Quick Start Guide**](./quick-start.md) - Step-by-step setup instructions
-- [**User Guide**](./USER_GUIDE.md) - Comprehensive BDD scenarios
-- [**Command Reference**](./command-reference.md) - All available commands
-- [**SSH Configuration**](./ssh-configuration.md) - Deep dive on VM-to-VM communication
-- [**Architecture**](./ARCHITECTURE.md) - How it all works under the hood
-
----
-
-## TL;DR (Because We Know You're Busy)
-
-**VDE gives you:**
-- 23 programming languages, ready in seconds
-- 8 shared services (databases, caching, etc.)
-- Isolated environments (no conflicts ever!)
-- VM-to-VM communication
-- Natural language control
-- Zero Docker knowledge required
-- One unified command: `vde`
-- A fun, encouraging community (that's you!)
-
-**You give it:**
-- Four commands to get started
-
-**Want to leave?**
-- Two commands to completely remove it
-
-**Fair trade?** We think so! 💪
-
----
-
 [← Back to README](../README.md)
-
----
-
-**P.S.** You're going to do amazing things with VDE. We can't wait to see what you create! ✨🚀
 
 *[Home](../README.md) | [Quick Start](./quick-start.md) | [Documentation](./)*


### PR DESCRIPTION
## Objective
Align the public-facing 'Why VDE' guide with the 1.4.1 Sovereign Baseline's hardened state.

## What Was Wrong
The documentation was architecturally inaccurate regarding prerequisites and workspace persistence.

## The Fix
Overhauled the guide to reflect the Unyielding Tetrad, WSL2 parity, and automated persistence.

## Verification
- Documentation verified for accuracy.
- Proof of Life Certified.

Closes #131