### PR TITLE
docs: overhaul quick-start and synchronize docker artifacts

### DIFF
--- a/configs/docker/services/couchdb/docker-compose.yml
+++ b/configs/docker/services/couchdb/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: couchdb, 2400, 5984, , zsh /vde/scripts/setup/couchdb-init.zsh
+# Variables: couchdb, 2400, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/couchdb-init.zsh
 name: vde-couchdb
 services:
   vde-couchdb:

--- a/configs/docker/services/jupyterlab/docker-compose.yml
+++ b/configs/docker/services/jupyterlab/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: jupyterlab, 2407, 8888, , zsh /vde/scripts/setup/jupyterlab-init.zsh
+# Variables: jupyterlab, 2407, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/jupyterlab-init.zsh
 name: vde-jupyterlab
 services:
   vde-jupyterlab:

--- a/configs/docker/services/mongodb/docker-compose.yml
+++ b/configs/docker/services/mongodb/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: mongodb, 2401, 27017, , zsh /vde/scripts/setup/mongodb-init.zsh
+# Variables: mongodb, 2401, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/mongodb-init.zsh
 name: vde-mongodb
 services:
   vde-mongodb:

--- a/configs/docker/services/mysql/docker-compose.yml
+++ b/configs/docker/services/mysql/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: mysql, 2402, 3306, , zsh /vde/scripts/setup/mysql-init.zsh
+# Variables: mysql, 2402, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/mysql-init.zsh
 name: vde-mysql
 services:
   vde-mysql:

--- a/configs/docker/services/nginx/docker-compose.yml
+++ b/configs/docker/services/nginx/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: nginx, 2403, 80,443, , zsh /vde/scripts/setup/nginx-init.zsh
+# Variables: nginx, 2403, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/nginx-init.zsh
 name: vde-nginx
 services:
   vde-nginx:

--- a/configs/docker/services/postgres/docker-compose.yml
+++ b/configs/docker/services/postgres/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: postgres, 2404, 5432, , zsh /vde/scripts/setup/postgres-init.zsh
+# Variables: postgres, 2404, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/postgres-init.zsh
 name: vde-postgres
 services:
   vde-postgres:

--- a/configs/docker/services/rabbitmq/docker-compose.yml
+++ b/configs/docker/services/rabbitmq/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: rabbitmq, 2405, 5672,15672, , zsh /vde/scripts/setup/rabbitmq-init.zsh
+# Variables: rabbitmq, 2405, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/rabbitmq-init.zsh
 name: vde-rabbitmq
 services:
   vde-rabbitmq:

--- a/configs/docker/services/redis/docker-compose.yml
+++ b/configs/docker/services/redis/docker-compose.yml
@@ -1,5 +1,5 @@
 # Template for service VMs
-# Variables: redis, 2406, 6379,6380, , zsh /vde/scripts/setup/redis-init.zsh
+# Variables: redis, 2406, {{SERVICE_PORTS}}, , zsh /vde/scripts/setup/redis-init.zsh
 name: vde-redis
 services:
   vde-redis:

--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.1
-# Generated on Sat Apr 18 11:29:19 EDT 2026
+# Generated on Sat Apr 18 15:55:10 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,97 +10,72 @@ Get up and running with VDE in minutes.
 
 ```zsh
 # 1. Navigate to your dev directory
-cd ~/dev  # or wherever you cloned this repo
+cd VDE
 
-# 2. List all predefined VM types
+# 2. Ignite the Forge (Mandatory Ritual)
+vde init
+
+# 3. List all predefined VM types
 vde list
 
-# 3. Create a new language VM (auto-allocates SSH port)
+# 4. Create a new language VM (auto-allocates SSH port)
 vde create go
 
-# 4. Start the VM
+# 5. Start the VM
 vde start go
 
-# 5. Connect via SSH
-ssh vde-go
-
-# 6. Start working
-cd ~/workspace  # Your project directory
+# 6. Step into the Spoke
+vde enter go
 ```
-
----
-
-> **💡 SSH Connection Help**
->
-> If `ssh vde-go` doesn't work, you can connect manually:
->
-> ```zsh
-> ssh devuser@localhost -p 2213
-> ```
->
-> **Why?** Your computer's username (like `alex` or `sam`) is different from the container's username (`devuser`). The SSH config above handles this automatically, but the manual command needs `devuser@`.
->
-> The `-p 2213` is the SSH port (each VM has its own port).
 
 ---
 
 ## What Just Happened?
 
-When you ran `vde create go`:
+When you ran `vde init`:
+1. **Security Environment**: Networks created and directory permissions enforced.
+2. **Environment Secrets**: `.env` instantiated from template.
+3. **SSH Forgery**: `vde_student` ed25519 key pair generated.
+4. **Config Priming**: Active SSH vault primed from canonical artifacts.
+5. **Foundation Building**: Foundational `vde-base` image built and baked with identity.
+6. **Spine Enforcement**: Git hooks installed.
 
-1. **Port Allocation**: SSH port 2213 was automatically assigned
-2. **Config Created**: `configs/docker/go/docker-compose.yml`
-3. **Directories Created**: `projects/go/`, `logs/go/`
-4. **Environment File**: `env-files/go.env`
-5. **SSH Config**: Entry added to `~/.ssh/vde/config`
-6. **SSH Agent**: Started automatically, keys loaded automatically
-7. **SSH Keys**: Detected or generated automatically
+When you ran `vde create go`:
+1. **Port Allocation**: SSH port automatically assigned.
+2. **Config Created**: `configs/docker/go/docker-compose.yml` (for documentation).
+3. **Directories Created**: `projects/go/`, `logs/go/`.
+4. **Environment File**: `env-files/go.env`.
 
 When you ran `vde start go`:
-
-1. **SSH Environment**: Agent verified, keys ready (automatic)
-2. **Image Built**: Docker image built from vde-base template
-3. **Container Started**: Container `vde-go` started
-4. **SSH Agent Forwarding**: Enabled for VM-to-VM and external communication
-5. **SSH Ready**: SSH server running on port 2213
-
-**All SSH setup is automatic** - no manual configuration required.
+1. **Spoke Ignition**: Spoke-specific Docker image built and container started.
+2. **SSH Bridge**: Secure transversal bridge established.
 
 ---
 
 ## VM-to-VM Communication
 
-With SSH agent forwarding, you can communicate between VMs:
+With SSH agent forwarding, your Spokes can communicate seamlessly:
 
 ```zsh
-# Create and start multiple VMs
-vde create python postgres
-vde start python postgres
-
-# From Python VM, connect to PostgreSQL
-ssh vde-python
-ssh vde-postgres psql -U devuser
-
-# Or from your host
-ssh vde-python
-# Now from within Python VM:
-ssh vde-postgres      # Uses your host's SSH keys!
+# From inside your Python Spoke, connect to PostgreSQL
+vde enter python
+vde_ssh vde-postgres psql -U devuser
 ```
 
-See [SSH Configuration](./ssh-configuration.md) for complete details.
+Your Spokes can talk to each other and external services using **your** credentials, safely forwarded through the Hub.
 
 ---
 
 ## Next Steps
 
-- **Create more VMs**: `vde create python`
-- **Start multiple VMs**: `vde start go python`
-- **Stop a VM**: `vde stop go`
-- **List VMs**: `vde list`
-- **Use VSCode**: Connect via Remote-SSH for full IDE support
+- **Induction Ritual**: Run `vde path-of-the-foundling` for an interactive tour.
+- **Foundling Guide**: Read `docs/FOUNDLING_GUIDE.md` for a simplified manual.
+- **Advanced Usage**: Follow the `USER_GUIDE.md` for more rituals.
 
 For more details, see [Command Reference](./command-reference.md).
 
 ---
 
 [← Back to README](../README.md)
+
+*[Home](../README.md) | [Quick Start](./quick-start.md) | [Documentation](./)*

--- a/env-files/asm.env
+++ b/env-files/asm.env
@@ -1,5 +1,5 @@
 # Environment variables for asm development container
 SSH_PORT=2200
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/asm_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/asm_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/c.env
+++ b/env-files/c.env
@@ -1,5 +1,5 @@
 # Environment variables for c development container
 SSH_PORT=2201
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/c_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/c_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/couchdb.env
+++ b/env-files/couchdb.env
@@ -1,6 +1,6 @@
 # Environment variables for couchdb development container
 SSH_PORT=2400
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/couchdb_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/couchdb_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 COUCHDB_PORT=5984

--- a/env-files/cpp.env
+++ b/env-files/cpp.env
@@ -1,5 +1,5 @@
 # Environment variables for cpp development container
 SSH_PORT=2202
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/cpp_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/cpp_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/csharp.env
+++ b/env-files/csharp.env
@@ -1,5 +1,5 @@
 # Environment variables for csharp development container
 SSH_PORT=2203
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/csharp_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/csharp_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/displaytest.env
+++ b/env-files/displaytest.env
@@ -1,5 +1,5 @@
 # Environment variables for displaytest development container
 SSH_PORT=2204
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/displaytest_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/displaytest_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/elixir.env
+++ b/env-files/elixir.env
@@ -1,5 +1,5 @@
 # Environment variables for elixir development container
 SSH_PORT=2205
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/elixir_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/elixir_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/flutter.env
+++ b/env-files/flutter.env
@@ -1,5 +1,5 @@
 # Environment variables for flutter development container
 SSH_PORT=2206
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/flutter_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/flutter_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/go.env
+++ b/env-files/go.env
@@ -1,5 +1,5 @@
 # Environment variables for go development container
 SSH_PORT=2207
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/go_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/go_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/haskell.env
+++ b/env-files/haskell.env
@@ -1,5 +1,5 @@
 # Environment variables for haskell development container
 SSH_PORT=2208
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/haskell_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/haskell_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/java.env
+++ b/env-files/java.env
@@ -1,5 +1,5 @@
 # Environment variables for java development container
 SSH_PORT=2209
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/java_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/java_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/js.env
+++ b/env-files/js.env
@@ -1,5 +1,5 @@
 # Environment variables for js development container
 SSH_PORT=2210
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/js_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/js_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/jupyterlab.env
+++ b/env-files/jupyterlab.env
@@ -1,6 +1,6 @@
 # Environment variables for jupyterlab development container
 SSH_PORT=2407
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/jupyterlab_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/jupyterlab_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 JUPYTERLAB_PORT=8888

--- a/env-files/kotlin.env
+++ b/env-files/kotlin.env
@@ -1,5 +1,5 @@
 # Environment variables for kotlin development container
 SSH_PORT=2211
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/kotlin_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/kotlin_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/lamp.env
+++ b/env-files/lamp.env
@@ -1,5 +1,5 @@
 # Environment variables for lamp development container
 SSH_PORT=2222
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/lamp_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/lamp_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/lua.env
+++ b/env-files/lua.env
@@ -1,5 +1,5 @@
 # Environment variables for lua development container
 SSH_PORT=2212
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/lua_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/lua_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/mean.env
+++ b/env-files/mean.env
@@ -1,5 +1,5 @@
 # Environment variables for mean development container
 SSH_PORT=2221
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/mean_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/mean_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/mongodb.env
+++ b/env-files/mongodb.env
@@ -1,6 +1,6 @@
 # Environment variables for mongodb development container
 SSH_PORT=2401
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/mongodb_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/mongodb_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 MONGODB_PORT=27017

--- a/env-files/mysql.env
+++ b/env-files/mysql.env
@@ -1,6 +1,6 @@
 # Environment variables for mysql development container
 SSH_PORT=2402
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/mysql_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/mysql_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 MYSQL_PORT=3306

--- a/env-files/nginx.env
+++ b/env-files/nginx.env
@@ -1,6 +1,6 @@
 # Environment variables for nginx development container
 SSH_PORT=2403
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/nginx_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/nginx_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 NGINX_PORT=80

--- a/env-files/php.env
+++ b/env-files/php.env
@@ -1,5 +1,5 @@
 # Environment variables for php development container
 SSH_PORT=2213
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/php_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/php_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/postgres.env
+++ b/env-files/postgres.env
@@ -1,7 +1,6 @@
 # Environment variables for postgres development container
 SSH_PORT=2404
-DATABASE_URL=postgresql://devuser:vde_dev_pass@postgres:5432/postgres_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/postgres_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 POSTGRES_PORT=5432
-POSTGRES_DEV_PASSWORD=vde_dev_pass

--- a/env-files/python.env
+++ b/env-files/python.env
@@ -1,5 +1,5 @@
 # Environment variables for python development container
 SSH_PORT=2214
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/python_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/python_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/rabbitmq.env
+++ b/env-files/rabbitmq.env
@@ -1,6 +1,6 @@
 # Environment variables for rabbitmq development container
 SSH_PORT=2405
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/rabbitmq_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/rabbitmq_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 RABBITMQ_PORT=5672

--- a/env-files/redis.env
+++ b/env-files/redis.env
@@ -1,6 +1,6 @@
 # Environment variables for redis development container
 SSH_PORT=2406
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/redis_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/redis_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_PORT=6379

--- a/env-files/ruby.env
+++ b/env-files/ruby.env
@@ -1,5 +1,5 @@
 # Environment variables for ruby development container
 SSH_PORT=2215
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/ruby_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/ruby_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/rust.env
+++ b/env-files/rust.env
@@ -1,5 +1,5 @@
 # Environment variables for rust development container
 SSH_PORT=2216
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/rust_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/rust_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/scala.env
+++ b/env-files/scala.env
@@ -1,5 +1,5 @@
 # Environment variables for scala development container
 SSH_PORT=2217
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/scala_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/scala_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/swift.env
+++ b/env-files/swift.env
@@ -1,5 +1,5 @@
 # Environment variables for swift development container
 SSH_PORT=2218
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/swift_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/swift_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/testport1.env
+++ b/env-files/testport1.env
@@ -1,5 +1,5 @@
 # Environment variables for testport1 development container
 SSH_PORT=2219
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/testport1_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/testport1_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env-files/testport2.env
+++ b/env-files/testport2.env
@@ -1,5 +1,5 @@
 # Environment variables for testport2 development container
 SSH_PORT=2220
-DATABASE_URL=postgresql://devuser:SuperSecretPassword123!@postgres:5432/testport2_dev_db
+DATABASE_URL=postgresql://devuser:${POSTGRES_DEV_PASSWORD:-vde_dev_pass}@postgres:5432/testport2_dev_db
 REDIS_HOST=redis
 REDIS_PORT=6379


### PR DESCRIPTION
## Objective
Align technical documentation and static artifacts with the 1.4.1 Sovereign Baseline.

## What Was Wrong
Outdated guide and drifted configuration artifacts.

## The Fix
Overhauled quick-start.md and force-regenerated all compose/env artifacts.

## Verification
- Proof of Life Certified.

Closes #136