### PR TITLE
release: synchronize stable mirror to 1.4.1 baseline

### DIFF
--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.1
-# Generated on Sat Apr 18 15:55:10 EDT 2026
+# Generated on Sat Apr 18 16:17:26 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:


### PR DESCRIPTION
## Objective
Publicly anchor the 1.4.1 baseline on the stable mirror.

## What Was Wrong
The stable mirror was at an older 1.4.1 intermediate state and missing final document overhauls.

## The Reforging
Merge main into stable.

## The Beskar Set
- All 1.4.1 evolution artifacts.

Closes #146

## Summary by Sourcery

Synchronize the stable SSH configuration with the 1.4.1 baseline without introducing functional changes.