### PR TITLE
fix(rust): harden Cargo PATH using relative paths in devuser shell configs

### DIFF
--- a/scripts/setup/rust-init.zsh
+++ b/scripts/setup/rust-init.zsh
@@ -21,35 +21,42 @@ apt-get install -y ${=vde_rust_pkgs}
 # Rust-Specific Smelting: Install rustup via the Sovereign Mirror.
 # This ensures the Spoke is "Born Ready" (BTO) at image creation.
 # Using the standard mirror with hardened TLS requirements.
-# We ensure the home directory exists before installation.
-mkdir -p /home/devuser
-chown devuser:devuser /home/devuser
-
 sudo -u devuser sh -c 'if ! command -v rustc >/dev/null; then \
   curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path; \
 fi'
 
 # 3. PERSISTENCE ANCHORS (User Personalization & Shell Integration)
-# Injects pathing and environment variables into .zshenv.
+# Injects pathing and environment variables into .zshenv and .zshrc.
 # These anchors ensure that the Rust toolchain and Sovereign Bridge 
 # survive 'vde rebuild' and 'vde stop/start' cycles.
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
-touch "${_zshenv}"
+local dev_home="~devuser"
+local _zshenv="${dev_home}/.zshenv"
+local _zshrc="${dev_home}/.zshrc"
+
+touch "${_zshenv}" "${_zshrc}"
 
 # Anchor: Rust Toolchain Pathing
 # Ensures cargo and rustc are available immediately upon 'vde enter'.
-grep -q "cargo/env" "${_zshenv}" || {
-  echo 'source $HOME/.cargo/env' >> "${_zshenv}"
+# .zshenv handles environment for all shells (mandated for non-interactive tools).
+grep -q "cargo/bin" "${_zshenv}" || {
+  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "${_zshenv}"
+}
+
+# .zshrc ensures interactive shell path inheritance and prioritization.
+# This fixes IS171 where Cargo was missing in interactive devuser sessions.
+grep -q "cargo/bin" "${_zshrc}" || {
+  echo '' >> "${_zshrc}"
+  echo '# Rust Toolchain' >> "${_zshrc}"
+  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "${_zshrc}"
 }
 
 # Anchor: Sovereign SSH Bridge identity 
 # Mandated by the Rule Spine for Git operations using host keys.
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-  echo 'if [[ -z "${SSH_AUTH_SOCK}" ]]; then export SSH_AUTH_SOCK="/home/devuser/.ssh/vde/agent.sock"; fi' >> "${_zshenv}"
+  echo 'if [[ -z "${SSH_AUTH_SOCK}" ]]; then export SSH_AUTH_SOCK="$HOME/.ssh/vde/agent.sock"; fi' >> "${_zshenv}"
 }
 
-chown devuser:devuser "${_zshenv}"
+chown devuser:devuser "${_zshenv}" "${_zshrc}"
 
 # 4. PURGING THE GHOSTS
 # Clean up build artifacts to maintain a hardened, immutable baseline.

--- a/tests/features/core-infrastructure/rust-path-repro.feature
+++ b/tests/features/core-infrastructure/rust-path-repro.feature
@@ -1,0 +1,17 @@
+@core-infrastructure @rust @path
+Feature: Rust VM Path Verification
+  As a developer using the Rust VM
+  I require the Cargo bin directory to be in my PATH
+  So that I can execute cargo commands immediately
+
+  Scenario: Verify Cargo is in PATH for interactive shell
+    Given the container "vde-rust" is running
+    When I execute "bin/vde enter rust --command 'echo $PATH'"
+    Then the output should contain "/home/devuser/.cargo/bin"
+    And the return code should be 0
+
+  Scenario: Verify Cargo command is executable
+    Given the container "vde-rust" is running
+    When I execute "bin/vde enter rust --command 'cargo --version'"
+    Then the output should contain "cargo"
+    And the return code should be 0


### PR DESCRIPTION
## Fracture Analysis
Cargo bin directory was missing from the `devuser` interactive PATH due to missing entries in `.zshrc` and reliance on hardcoded paths.

## The Reforging
- Updated `scripts/setup/rust-init.zsh` to use relative paths (`~devuser`, `$HOME`).
- Ensured Cargo bin directory is prepended to PATH in both `.zshenv` and `.zshrc`.
- Guaranteed toolchain availability across all shell types for `devuser`.
- Added empirical BDD test for PATH verification.

## The Beskar Set
- `scripts/setup/rust-init.zsh`
- `tests/features/core-infrastructure/rust-path-repro.feature`

Closes #171