### PR TITLE
fix(setup): remove hardcoded /home/devuser paths from hydration scripts

### DIFF
--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.1
-# Generated on Sun Apr 19 15:20:29 EDT 2026
+# Generated on Sun Apr 19 15:41:51 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:

--- a/docs/superpowers/plans/2026-04-18-fix-rust-init-tilde-expansion.md
+++ b/docs/superpowers/plans/2026-04-18-fix-rust-init-tilde-expansion.md
@@ -1,0 +1,97 @@
+# Fix Tilde Expansion Bug in rust-init.zsh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unquote `local dev_home=~devuser` in `scripts/setup/rust-init.zsh` to allow Zsh tilde expansion.
+
+**Architecture:** Use a surgical edit to remove quotes from the variable assignment, ensuring tilde expansion works as expected in Zsh.
+
+**Tech Stack:** Zsh
+
+---
+
+### Task 1: Initialize Strike and Branch
+
+**Files:**
+- Create: `gh issue create`
+- Modify: `git checkout -b fix/rust-init-tilde-expansion`
+
+- [ ] **Step 1: Open Signet of Intent**
+
+Run: `gh issue create --title "Fix: Tilde expansion bug in rust-init.zsh" --body "The local variable dev_home is quoted, preventing tilde expansion in Zsh. This causes setup failures when used in paths."`
+Expected: Issue number returned (e.g., #181)
+
+- [ ] **Step 2: Forge Feature Branch**
+
+Run: `git checkout -b fix/rust-init-tilde-expansion`
+Expected: Switched to a new branch 'fix/rust-init-tilde-expansion'
+
+### Task 2: Apply the Reforging
+
+**Files:**
+- Modify: `scripts/setup/rust-init.zsh:37`
+
+- [ ] **Step 1: Apply surgical edit to unquote dev_home**
+
+```zsh
+# OLD: local dev_home="~devuser"
+# NEW: local dev_home=~devuser
+```
+
+Run: `replace` tool on `scripts/setup/rust-init.zsh`
+```javascript
+{
+  "file_path": "/Users/dderyldowney/VDE/scripts/setup/rust-init.zsh",
+  "old_string": "local dev_home=\"~devuser\"",
+  "new_string": "local dev_home=~devuser",
+  "instruction": "Unquote dev_home assignment to allow Zsh tilde expansion per MANDATE."
+}
+```
+
+- [ ] **Step 2: Verify the edit**
+
+Run: `grep "local dev_home=~devuser" scripts/setup/rust-init.zsh`
+Expected: Line 37 matches exactly (no quotes).
+
+### Task 3: Empirical Verification
+
+**Files:**
+- Run: `plans/scripts/repro_tilde_bug.zsh`
+
+- [ ] **Step 1: Run reproduction script to confirm fix logic**
+
+Run: `zsh /Users/dderyldowney/VDE/plans/scripts/repro_tilde_bug.zsh`
+Expected: Output confirms unquoted tilde expands to a path (e.g., `/var/root`).
+
+- [ ] **Step 2: Verify no regressions in rust-init.zsh**
+
+Run: `zsh -n /Users/dderyldowney/VDE/scripts/setup/rust-init.zsh`
+Expected: No syntax errors.
+
+### Task 4: Submit Chronicle and Cleanup
+
+**Files:**
+- Modify: `gh pr create`
+
+- [ ] **Step 1: Commit the Reforging**
+
+Run: `git add scripts/setup/rust-init.zsh`
+Run: `git commit -m "fix(setup): unquote dev_home for tilde expansion in rust-init.zsh"`
+Expected: Commit successful.
+
+- [ ] **Step 2: Present Chronicle for Clan Leader Review**
+
+Action: Report PR body and Issue linkage.
+PR Body:
+(1) Fracture Analysis: `local dev_home="~devuser"` prevented tilde expansion.
+(2) The Reforging: Removed quotes to allow expansion.
+(3) The Beskar Set: `scripts/setup/rust-init.zsh`
+
+- [ ] **Step 3: Create Chronicle (Wait for Approval)**
+
+Run: `gh pr create --title "fix: unquote dev_home in rust-init.zsh" --body "Fracture Analysis: local dev_home='~devuser' prevented tilde expansion.\nThe Reforging: Removed quotes to allow expansion.\nThe Beskar Set: scripts/setup/rust-init.zsh\n\nCloses #<ISSUE_NUMBER>"`
+
+- [ ] **Step 4: Cleanup Staging**
+
+Run: `rm /Users/dderyldowney/VDE/plans/scripts/repro_tilde_bug.zsh`
+Expected: Artifact removed.

--- a/docs/superpowers/specs/2026-04-18-fix-rust-init-tilde-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-18-fix-rust-init-tilde-expansion-design.md
@@ -1,0 +1,18 @@
+# Strike Design: Fix Tilde Expansion Bug in rust-init.zsh
+
+## Fracture Analysis
+File: `scripts/setup/rust-init.zsh`
+Location: Line 37
+Issue: `local dev_home="~devuser"` uses double quotes, which prevents Zsh from performing tilde expansion. This results in the literal string `~devuser` being assigned to the variable, causing downstream operations (touch, grep, echo) to fail when they expect a valid filesystem path.
+
+## The Reforging
+Change: `local dev_home="~devuser"` -> `local dev_home=~devuser`
+Rationale: Per Zsh specification and Mandate, unquoted tilde at the start of an assignment allows for expansion to the user's home directory.
+
+## Success Criteria
+1. `local dev_home=~devuser` is unquoted in `scripts/setup/rust-init.zsh`.
+2. No other changes are made to the file.
+3. Verification script confirms the change is applied correctly.
+
+## Beskar Set
+- `scripts/setup/rust-init.zsh`

--- a/plans/174-remove-hardcoded-paths.md
+++ b/plans/174-remove-hardcoded-paths.md
@@ -1,0 +1,33 @@
+# Implementation Plan: Fix Hardcoded Paths in Setup Scripts (Issue 174)
+
+## Objective
+Remove all hardcoded `/home/devuser` paths from the `scripts/setup/` hydration scripts to comply with the mandate for relative pathing and portability. Replace them with robust Zsh `~devuser` variable assignments.
+
+## Key Files & Context
+- **Affected Files:**
+  - `scripts/setup/couchdb-init.zsh`
+  - `scripts/setup/csharp-init.zsh`
+  - `scripts/setup/elixir-init.zsh`
+  - `scripts/setup/flutter-init.zsh`
+  - `scripts/setup/jupyterlab-init.zsh`
+  - `scripts/setup/kotlin-init.zsh`
+  - `scripts/setup/lamp-init.zsh`
+  - `scripts/setup/mean-init.zsh`
+  - `scripts/setup/mongodb-init.zsh`
+  - `scripts/setup/mysql-init.zsh`
+  - `scripts/setup/nginx-init.zsh`
+  - `scripts/setup/postgres-init.zsh`
+  - `scripts/setup/rabbitmq-init.zsh`
+  - `scripts/setup/redis-init.zsh`
+- **Context:** The scripts currently use `local _zshenv="/home/devuser/.zshenv"` or similar constructs. These violate the portability requirement.
+
+## Implementation Steps
+1. **Define Local Home Variable:** For each affected script, introduce a `local dev_home=~devuser` variable assignment near the beginning of the "PERSISTENCE ANCHORS" section (or wherever the hardcoded paths begin). Ensure the tilde expansion works correctly by avoiding quotes around `~devuser`.
+2. **Replace Hardcoded Paths:** Update all instances of `/home/devuser` within the script to use the `${dev_home}` variable. For example, `local _zshenv="${dev_home}/.zshenv"`.
+3. **Verify Expansion Context:** Double-check that tilde expansion is not hindered by quotes in the initial `dev_home` assignment.
+4. **Agent Swarm Dispatch:** Due to the number of files (>1), a swarm of `generalist` sub-agents will be dispatched to apply these changes concurrently, honoring the Rule Spine's multi-file edit restriction.
+
+## Verification & Testing
+1. **Audit Compliance:** Run `bin/vde-enforce-uap.zsh` to ensure all core mandates remain satisfied.
+2. **Grep Validation:** Perform a final `grep -r "/home/devuser" scripts/setup/*.zsh` to confirm no stragglers remain.
+3. **Proof of Life Certification:** Execute the absolute lifecycle test (`python3 -m behave tests/features/core-infrastructure/proof-of-life-the-contract.feature`) to verify that the Spoke hydration process is unharmed by the pathing changes.

--- a/plans/scripts/repro_tilde_bug.zsh
+++ b/plans/scripts/repro_tilde_bug.zsh
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+# VDE Repro: Tilde Expansion Bug
+# Verifies that quoted tilde doesn't expand in local assignment.
+
+local dev_home_quoted="~root"
+local dev_home_unquoted=~root
+
+echo "Quoted: ${dev_home_quoted}"
+echo "Unquoted: ${dev_home_unquoted}"
+
+if [[ "${dev_home_quoted}" == "~root" ]]; then
+  echo "BUG PROVEN: Quoted tilde failed to expand."
+fi
+
+if [[ "${dev_home_unquoted}" != "~root" ]]; then
+  echo "SUCCESS: Unquoted tilde expanded to ${dev_home_unquoted}."
+fi

--- a/scripts/setup/couchdb-init.zsh
+++ b/scripts/setup/couchdb-init.zsh
@@ -26,14 +26,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/couchdb start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/csharp-init.zsh
+++ b/scripts/setup/csharp-init.zsh
@@ -20,8 +20,9 @@ sh /tmp/dotnet-install.sh --version 8.0.100 --install-dir "${DOTNET_INSTALL_DIR}
 ln -sf "${DOTNET_INSTALL_DIR}/dotnet" /usr/bin/dotnet
 
 # 3. PERSISTENCE ANCHOR
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 grep -q "DOTNET_ROOT" "${_zshenv}" || {
     echo "export DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "${_zshenv}"

--- a/scripts/setup/elixir-init.zsh
+++ b/scripts/setup/elixir-init.zsh
@@ -16,6 +16,7 @@ apt-get install -y ${=vde_elixir_pkgs}
 locale-gen en_US.UTF-8
 
 # Installation for devuser
+local dev_home=~devuser
 INSTALL_SCRIPT="/tmp/install-elixir-as-devuser.sh"
 cat <<EOF > "${INSTALL_SCRIPT}"
 #!/usr/bin/env zsh
@@ -36,8 +37,8 @@ chmod +x "${INSTALL_SCRIPT}"
 su - devuser -c "${INSTALL_SCRIPT}"
 
 # 3. PERSISTENCE ANCHOR
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 grep -q "asdf.sh" "${_zshenv}" || {
     echo 'source $HOME/.asdf/asdf.sh' >> "${_zshenv}"

--- a/scripts/setup/flutter-init.zsh
+++ b/scripts/setup/flutter-init.zsh
@@ -4,6 +4,8 @@
 # Forged in Beskar
 set -e
 
+local dev_home=~devuser
+
 # 1. THE PACKAGE ALLOY
 export DEBIAN_FRONTEND=noninteractive
 local vde_flutter_pkgs="curl git unzip xz-utils zip libglu1-mesa docker.io"
@@ -13,14 +15,14 @@ apt-get update
 apt-get install -y ${=vde_flutter_pkgs}
 
 # Setup Flutter for devuser
-su devuser -c 'if [ ! -d "/home/devuser/flutter" ]; then git clone --depth 1 https://github.com/flutter/flutter.git /home/devuser/flutter; fi && export PATH="$PATH:/home/devuser/flutter/bin" && /home/devuser/flutter/bin/flutter precache'
+su devuser -c "if [ ! -d \"${dev_home}/flutter\" ]; then git clone --depth 1 https://github.com/flutter/flutter.git ${dev_home}/flutter; fi && export PATH=\"\$PATH:${dev_home}/flutter/bin\" && ${dev_home}/flutter/bin/flutter precache"
 
 # 3. PERSISTENCE ANCHOR
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 grep -q "flutter/bin" "${_zshenv}" || {
-    echo 'export PATH="$PATH:/home/devuser/flutter/bin"' >> "${_zshenv}"
+    echo "export PATH=\"\$PATH:${dev_home}/flutter/bin\"" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/jupyterlab-init.zsh
+++ b/scripts/setup/jupyterlab-init.zsh
@@ -13,7 +13,8 @@ apt-get update
 apt-get install -y ${=vde_jupyter_pkgs}
 
 # 3. Create a dedicated venv for Jupyter
-local _venv_path="/home/devuser/.vde-venv"
+local dev_home=~devuser
+local _venv_path="${dev_home}/.vde-venv"
 sudo -u devuser python3 -m venv "${_venv_path}"
 
 # 4. Install DS stack (Refined 2026 Alloy)
@@ -36,13 +37,13 @@ sudo -u devuser "${_venv_path}/bin/pip" install \
     jupysql
 
 # 5. CONFIGURE JUPYTER SERVER (Modern Pattern)
-local _jupyter_config="/home/devuser/.jupyter/jupyter_server_config.py"
-sudo -u devuser mkdir -p /home/devuser/.jupyter
+local _jupyter_config="${dev_home}/.jupyter/jupyter_server_config.py"
+sudo -u devuser mkdir -p ${dev_home}/.jupyter
 sudo -u devuser zsh -c "cat <<EOF > ${_jupyter_config}
 c.ServerApp.ip = '0.0.0.0'
 c.ServerApp.port = 8888
 c.ServerApp.open_browser = False
-c.ServerApp.root_dir = '/home/devuser/workspace'
+c.ServerApp.root_dir = '${dev_home}/workspace'
 c.ServerApp.allow_root = True
 c.ServerApp.allow_remote_access = True
 c.ServerApp.disable_check_xsrf = True
@@ -52,8 +53,8 @@ c.IdentityProvider.password = ''
 EOF"
 
 # 6. PERSISTENCE ANCHOR (Hardened Background Pattern)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 
 # Ensure logs directory exists for the service
@@ -62,7 +63,7 @@ chown devuser:devuser /logs
 
 # Guarded bridge setup (Jupyter startup moved to Ignition Hook)
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 
 # 6.1 INTER-VM AWARENESS (Cluster Bonding)
@@ -89,7 +90,7 @@ chmod +x "${_spoke_ignition}"
 # 8. PERMISSION FINALIZATION
 # Set ownership now to avoid slow recursive chown at runtime
 chown -R devuser:devuser "${_venv_path}"
-chown -R devuser:devuser /home/devuser/.jupyter
+chown -R devuser:devuser ${dev_home}/.jupyter
 
 # 9. PURGING THE GHOSTS
 apt-get clean

--- a/scripts/setup/kotlin-init.zsh
+++ b/scripts/setup/kotlin-init.zsh
@@ -15,7 +15,8 @@ mkdir -p /usr/share/man/man1
 apt-get install -y ${=vde_kotlin_pkgs}
 
 # SDKMAN INITIALIZATION
-export SDKMAN_DIR="/home/devuser/.sdkman"
+local dev_home=~devuser
+export SDKMAN_DIR="${dev_home}/.sdkman"
 export sdkman_auto_answer=true
 
 # Force clean start if directory is a ghost
@@ -35,8 +36,8 @@ if [[ -f "$_sdk_init" ]]; then
 fi
 
 # 3. PERSISTENCE ANCHOR
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 grep -q "SDKMAN_DIR" "${_zshenv}" || {
     {

--- a/scripts/setup/lamp-init.zsh
+++ b/scripts/setup/lamp-init.zsh
@@ -13,8 +13,9 @@ apt-get update
 apt-get install -y ${=vde_lamp_pkgs}
 
 # 3. CLUSTER COORDINATION
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 grep -q "DB_HOST" "${_zshenv}" || {
     echo "export DB_HOST=vde-mysql" >> "${_zshenv}"

--- a/scripts/setup/mean-init.zsh
+++ b/scripts/setup/mean-init.zsh
@@ -18,8 +18,9 @@ sh /tmp/setup_node.sh
 apt-get install -y nodejs
 
 # 3. CLUSTER COORDINATION
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 grep -q "MONGO_URI" "${_zshenv}" || {
     echo "export MONGO_URI=mongodb://vde-mongodb:27017" >> "${_zshenv}"

--- a/scripts/setup/mongodb-init.zsh
+++ b/scripts/setup/mongodb-init.zsh
@@ -26,14 +26,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/mongodb start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/mysql-init.zsh
+++ b/scripts/setup/mysql-init.zsh
@@ -26,14 +26,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p ${dev_home}
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/mysql start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/nginx-init.zsh
+++ b/scripts/setup/nginx-init.zsh
@@ -26,14 +26,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/nginx start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/postgres-init.zsh
+++ b/scripts/setup/postgres-init.zsh
@@ -59,14 +59,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/postgresql start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/rabbitmq-init.zsh
+++ b/scripts/setup/rabbitmq-init.zsh
@@ -26,14 +26,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/rabbitmq-server start/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/redis-init.zsh
+++ b/scripts/setup/redis-init.zsh
@@ -34,14 +34,15 @@ EOF
 chmod +x "${_spoke_ignition}"
 
 # 4. PERSISTENCE ANCHOR (Hardened Bridge)
-local _zshenv="/home/devuser/.zshenv"
-mkdir -p /home/devuser
+local dev_home=~devuser
+local _zshenv="${dev_home}/.zshenv"
+mkdir -p "${dev_home}"
 touch "${_zshenv}"
 # Remove legacy startup if present
 sed -i "/redis-server/d" "${_zshenv}"
 # Ensure bridge identity is available
 grep -q "SSH_AUTH_SOCK" "${_zshenv}" || {
-    echo "export SSH_AUTH_SOCK=/home/devuser/.ssh/vde/agent.sock" >> "${_zshenv}"
+    echo "export SSH_AUTH_SOCK=${dev_home}/.ssh/vde/agent.sock" >> "${_zshenv}"
 }
 chown devuser:devuser "${_zshenv}"
 

--- a/scripts/setup/rust-init.zsh
+++ b/scripts/setup/rust-init.zsh
@@ -29,7 +29,7 @@ fi'
 # Injects pathing and environment variables into .zshenv and .zshrc.
 # These anchors ensure that the Rust toolchain and Sovereign Bridge 
 # survive 'vde rebuild' and 'vde stop/start' cycles.
-local dev_home="~devuser"
+local dev_home=~devuser
 local _zshenv="${dev_home}/.zshenv"
 local _zshrc="${dev_home}/.zshrc"
 


### PR DESCRIPTION
## Fracture Analysis
Hydration scripts were utilizing hardcoded `/home/devuser` paths, violating the mandate for relative pathing and portability.

## The Reforging
- Standardized 15 hydration scripts in `scripts/setup/` to use dynamic `${dev_home}` variables.
- Initialized home directory resolution via unquoted `~devuser` tilde expansion.
- Verified 100% removal of hardcoded `/home/devuser` references.
- Confirmed Spoke hydration integrity via Proof of Life certification.

## The Beskar Set
- `scripts/setup/couchdb-init.zsh`
- `scripts/setup/csharp-init.zsh`
- `scripts/setup/elixir-init.zsh`
- `scripts/setup/flutter-init.zsh`
- `scripts/setup/jupyterlab-init.zsh`
- `scripts/setup/kotlin-init.zsh`
- `scripts/setup/lamp-init.zsh`
- `scripts/setup/mean-init.zsh`
- `scripts/setup/mongodb-init.zsh`
- `scripts/setup/mysql-init.zsh`
- `scripts/setup/nginx-init.zsh`
- `scripts/setup/postgres-init.zsh`
- `scripts/setup/rabbitmq-init.zsh`
- `scripts/setup/redis-init.zsh`
- `scripts/setup/rust-init.zsh`

Closes #174