### PR TITLE
fix(docs): align legacy terminology in superpowers docs

### DIFF
--- a/docs/superpowers/plans/2026-04-08-vde-jupyterlab-implementation.md
+++ b/docs/superpowers/plans/2026-04-08-vde-jupyterlab-implementation.md
@@ -25,7 +25,7 @@
   "display": "JupyterLab Data Science Suite",
   "pkgs": "python3-pip python3-venv",
   "custom_cmd": "zsh /vde/scripts/setup/jupyterlab-init.zsh",
-  "service_port": "8888",
+  "service_ports": "8888",
   "ssh_port": 2407
 }
 ```

--- a/docs/superpowers/specs/2026-04-08-vde-jupyterlab-design.md
+++ b/docs/superpowers/specs/2026-04-08-vde-jupyterlab-design.md
@@ -20,7 +20,7 @@ The `vde-jupyterlab` VM is categorized as a **Service** spoke to allow for expos
   "display": "JupyterLab Data Science Suite",
   "pkgs": "python3-pip python3-venv",
   "custom_cmd": "zsh /vde/scripts/setup/jupyterlab-init.zsh",
-  "service_port": "8888",
+  "service_ports": "8888",
   "ssh_port": 2407
 }
 ```


### PR DESCRIPTION
## Fracture Analysis
Legacy terminology (`service_port`) was found in Superpowers documentation artifacts, creating a minor drift from the Beskar Registry (`data/vm-types.json`).

## The Reforging
- Updated `docs/superpowers/` artifacts to use standardized `service_ports` terminology.
- Ensured 100% terminology alignment across all Gospel artifacts.

## The Beskar Set
- `docs/superpowers/plans/2026-04-08-vde-jupyterlab-implementation.md`
- `docs/superpowers/specs/2026-04-08-vde-jupyterlab-design.md`

Closes #175