### PR TITLE
chore(metrics): align jq calls with vde_query_json wrapper

### DIFF
--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,6 +1,6 @@
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.1
-# Generated on Sun Apr 19 15:41:51 EDT 2026
+# Generated on Sun Apr 19 16:00:43 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:

--- a/lib/vde-metrics
+++ b/lib/vde-metrics
@@ -13,6 +13,7 @@ local _zsh_compliance_flag=${(z):-"zsh native parameter expansion"}
 [[ -f "${VDE_ROOT_DIR}/lib/vde-constants" ]] && source "${VDE_ROOT_DIR}/lib/vde-constants"
 [[ -f "${VDE_ROOT_DIR}/lib/vde-shell-compat" ]] && source "${VDE_ROOT_DIR}/lib/vde-shell-compat"
 [[ -f "${VDE_ROOT_DIR}/lib/vde-log" ]] && source "${VDE_ROOT_DIR}/lib/vde-log"
+[[ -f "${VDE_ROOT_DIR}/lib/vde-core" ]] && source "${VDE_ROOT_DIR}/lib/vde-core"
 
 #===============================================================================
 # Metrics Configuration
@@ -98,15 +99,10 @@ vde_metrics_record() {
     # Create new metric entry
     local new_entry="{\"value\": ${value}, \"unit\": \"${unit}\", \"timestamp\": \"${timestamp}\"}"
     
-    # Use jq if available, otherwise fallback to simple append
-    if command -v jq >/dev/null 2>&1; then
-        echo "${metrics_json}" | jq --arg n "${escaped_name}" --argjson v "${new_entry}" \
-            '.metrics[$n] = .metrics[$n] // [] | .metrics[$n] += [$v] | .last_updated = "'"${timestamp}"'"' > "${VDE_METRICS_FILE}.${$}" 2>/dev/null
-        command mv "${VDE_METRICS_FILE}.${$}" "${VDE_METRICS_FILE}" 2>/dev/null
-    else
-        # Fallback: just append to counters in memory
-        _VDE_METRICS_COUNTERS["${metric_name}"]=$((${_VDE_METRICS_COUNTERS[${metric_name}]:-0} + value))
-    fi
+    # Use central wrapper for JQ operations (Rule G Hardening)
+    echo "${metrics_json}" | vde_query_json --arg n "${escaped_name}" --argjson v "${new_entry}" \
+        '.metrics[$n] = .metrics[$n] // [] | .metrics[$n] += [$v] | .last_updated = "'"${timestamp}"'"' > "${VDE_METRICS_FILE}.${$}" 2>/dev/null
+    command mv "${VDE_METRICS_FILE}.${$}" "${VDE_METRICS_FILE}" 2>/dev/null
     
     return 0
 }
@@ -182,11 +178,7 @@ vde_metrics_get() {
     local pattern="${1:-.*}"
     
     if [[ -f "${VDE_METRICS_FILE}" ]] ; then
-        if command -v jq >/dev/null 2>&1; then
-            command jq -r ".metrics | to_entries[] | select(.key | test(\"${pattern}\")) | \"\(.key): \(.value)\"" "${VDE_METRICS_FILE}" 2>/dev/null || true
-        else
-            command cat "${VDE_METRICS_FILE}"
-        fi
+        vde_query_json -r ".metrics | to_entries[] | select(.key | test(\"${pattern}\")) | \"\(.key): \(.value)\"" "${VDE_METRICS_FILE}" 2>/dev/null || true
     fi
 }
 
@@ -196,24 +188,18 @@ vde_metrics_get_value() {
     local metric_name="${1}"
     
     if [[ -f "${VDE_METRICS_FILE}" ]] ; then
-        if command -v jq >/dev/null 2>&1; then
-            command jq -r ".metrics[\"${metric_name}\"] | last | .value // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0"
-        fi
+        vde_query_json -r ".metrics[\"${metric_name}\"] | last | .value // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0"
     fi
 }
 
 # Get metrics statistics
 vde_metrics_stats() {
     if [[ -f "${VDE_METRICS_FILE}" ]] ; then
-        if command -v jq >/dev/null 2>&1; then
-            command jq '{
-                total_metrics: (.metrics | length),
-                last_updated: .last_updated,
-                sample_metrics: .metrics | to_entries |.[0:5] | map("\(.key): \(.value | length) entries")
-            }' "${VDE_METRICS_FILE}" 2>/dev/null || true
-        else
-            command cat "${VDE_METRICS_FILE}"
-        fi
+        vde_query_json '{
+            total_metrics: (.metrics | length),
+            last_updated: .last_updated,
+            sample_metrics: .metrics | to_entries |.[0:5] | map("\(.key): \(.value | length) entries")
+        }' "${VDE_METRICS_FILE}" 2>/dev/null || true
     fi
 }
 
@@ -239,11 +225,11 @@ vde_metrics_summary() {
     
     if [[ -f "${VDE_METRICS_FILE}" ]] ; then
         local total_entries
-        total_entries=$(command jq '.metrics | map_values(length) | values | add // 0' "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
+        total_entries=$(vde_query_json '.metrics | map_values(length) | values | add // 0' "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
         echo "Total metric entries: ${total_entries}"
         echo ""
         echo "Recent metrics:"
-        command jq -r '.metrics | to_entries[] | "  \(.key): \(.value | length) entries"' "${VDE_METRICS_FILE}" 2>/dev/null || true
+        vde_query_json -r '.metrics | to_entries[] | "  \(.key): \(.value | length) entries"' "${VDE_METRICS_FILE}" 2>/dev/null || true
     fi
 }
 
@@ -304,15 +290,13 @@ vde_metrics_record_cache_miss() {
 # Get cache hit rate percentage
 vde_metrics_get_cache_hit_rate() {
     if [[ -f "${VDE_METRICS_FILE}" ]] ; then
-        if command -v jq >/dev/null 2>&1; then
-            local hits=$(command jq -r ".metrics[\"${VDE_METRICS_CACHE_HIT_RATE}.hit\"] | length // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
-            local misses=$(command jq -r ".metrics[\"${VDE_METRICS_CACHE_HIT_RATE}.miss\"] | length // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
-            local total=$((hits + misses))
-            if [[ "${total}" -gt 0 ]] ; then
-                echo $((hits * 100 / total))
-            else
-                echo "0"
-            fi
+        local hits=$(vde_query_json -r ".metrics[\"${VDE_METRICS_CACHE_HIT_RATE}.hit\"] | length // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
+        local misses=$(vde_query_json -r ".metrics[\"${VDE_METRICS_CACHE_HIT_RATE}.miss\"] | length // 0" "${VDE_METRICS_FILE}" 2>/dev/null || echo "0")
+        local total=$((hits + misses))
+        if [[ "${total}" -gt 0 ]] ; then
+            echo $((hits * 100 / total))
+        else
+            echo "0"
         fi
     fi
 }

--- a/plans/176-align-jq-calls.md
+++ b/plans/176-align-jq-calls.md
@@ -1,0 +1,22 @@
+# Implementation Plan: Align jq Calls with vde_query_json Wrapper (Issue 176)
+
+## Objective
+Migrate direct `jq` calls in `lib/vde-metrics` to the `vde_query_json` safety wrapper to ensure full compliance with Rule G (The Scavenger's Ban) and provide a robust fallback to Docker-based parsing if the host lacks the `jq` binary.
+
+## Key Files & Context
+- **Affected Files:**
+  - `lib/vde-metrics`
+- **Context:** `lib/vde-metrics` currently performs manual capability checks (`if command -v jq`) and invokes `jq` directly, bypassing the centralized, fail-safe `vde_query_json` logic in `lib/vde-core`.
+
+## Implementation Steps
+1. **Analyze Direct jq Usage:** Review all direct `jq` occurrences in `lib/vde-metrics`.
+2. **Refactor to vde_query_json:** 
+   - Replace explicit `if command -v jq >/dev/null 2>&1; then` checks and `command jq` executions with direct calls to `vde_query_json`.
+   - The `vde_query_json` function inherently handles the existence check and Docker fallback.
+3. **Handle Edge Cases:** 
+   - If there are scenarios where a simple text-append fallback was used in the absence of `jq`, assess whether the guaranteed execution via `vde_query_json` (which falls back to Docker) renders the text-append fallback obsolete. Given the mandate for Zero-Host Dependency, `vde_query_json` should be the universal solution.
+
+## Verification & Testing
+1. **Audit Compliance:** Run `bin/vde-enforce-uap.zsh` to verify continued compliance with core mandates.
+2. **Validation Sweep:** Execute `grep` to ensure no direct `jq` calls remain in `lib/vde-metrics`.
+3. **Execution Test:** Run a metrics-dependent command (e.g., `bin/vde stats` or `bin/vde health`) to confirm the `vde_query_json` wrapper functions correctly in the metrics context.


### PR DESCRIPTION
## Fracture Analysis
`lib/vde-metrics` was calling `jq` directly and performing manual capability checks, bypassing the centralized `vde_query_json` safety layer.

## The Reforging
- Migrated all direct `jq` calls in `lib/vde-metrics` to the `vde_query_json` wrapper.
- Sourced `lib/vde-core` in `lib/vde-metrics` to ensure wrapper availability.
- Removed redundant host capability checks (`if command -v jq`), delegating the logic to the centralized wrapper.
- Verified 100% removal of direct `jq` invocations in the metrics library.

## The Beskar Set
- `lib/vde-metrics`

Closes #176