### PR TITLE
fix(core): remediate documentation drift and exit code collisions

### DIFF
--- a/bin/vde-health
+++ b/bin/vde-health
@@ -15,10 +15,10 @@ VDE_ROOT_DIR="${0:a:h:h}"
 vde_log_init 2>/dev/null || true
 
 # Health status codes
-readonly VDE_HEALTH_OK=0
-readonly VDE_HEALTH_MINOR=1
-readonly VDE_HEALTH_MAJOR=2
-readonly VDE_HEALTH_CRITICAL=3
+[[ -z "${VDE_HEALTH_OK}" ]] && readonly VDE_HEALTH_OK=0
+[[ -z "${VDE_HEALTH_MINOR}" ]] && readonly VDE_HEALTH_MINOR=30
+[[ -z "${VDE_HEALTH_MAJOR}" ]] && readonly VDE_HEALTH_MAJOR=31
+[[ -z "${VDE_HEALTH_CRITICAL}" ]] && readonly VDE_HEALTH_CRITICAL=32
 
 # Health check results
 typeset -gA _VDE_HEALTH_CHECKS=()
@@ -352,10 +352,10 @@ vde_health_report_text() {
     
     local status_text
     case "${_VDE_HEALTH_OVERALL}" in
-        0) status_text="HEALTHY" ;;
-        1) status_text="MINOR ISSUES" ;;
-        2) status_text="MAJOR ISSUES" ;;
-        3) status_text="CRITICAL FAILURE" ;;
+        ${VDE_HEALTH_OK}) status_text="HEALTHY" ;;
+        ${VDE_HEALTH_MINOR}) status_text="MINOR ISSUES" ;;
+        ${VDE_HEALTH_MAJOR}) status_text="MAJOR ISSUES" ;;
+        ${VDE_HEALTH_CRITICAL}) status_text="CRITICAL FAILURE" ;;
         *) status_text="UNKNOWN" ;;
     esac
     
@@ -404,10 +404,10 @@ vde_health_report_json() {
     
     local status_text
     case "${_VDE_HEALTH_OVERALL}" in
-        0) status_text="healthy" ;;
-        1) status_text="minor_issues" ;;
-        2) status_text="major_issues" ;;
-        3) status_text="critical" ;;
+        ${VDE_HEALTH_OK}) status_text="healthy" ;;
+        ${VDE_HEALTH_MINOR}) status_text="minor_issues" ;;
+        ${VDE_HEALTH_MAJOR}) status_text="major_issues" ;;
+        ${VDE_HEALTH_CRITICAL}) status_text="critical" ;;
         *) status_text="unknown" ;;
     esac
     

--- a/lib/vde-constants
+++ b/lib/vde-constants
@@ -57,6 +57,12 @@ VDE_ERR_CACHE_INVALID=11
 # Sync drift - JSON/Cache does not match Hub timestamp authority
 VDE_ERR_SYNC_DRIFT=13
 
+# Health Check Codes (30-39 range)
+VDE_HEALTH_OK=0
+VDE_HEALTH_MINOR=30
+VDE_HEALTH_MAJOR=31
+VDE_HEALTH_CRITICAL=32
+
 # =============================================================================
 # BRANCH CONFIGURATION
 # =============================================================================
@@ -304,6 +310,7 @@ if [[ "${VDE_TEST_MODE:-0}" -ne 1 ]] ; then
              VDE_ERR_TIMEOUT VDE_ERR_EXISTS VDE_ERR_DEPENDENCY VDE_ERR_DOCKER VDE_ERR_LOCK \
              VDE_ERR_INVALID_DATA VDE_ERR_CACHE_INVALID \
              VDE_ERR_LOCK_CONTENTION VDE_ERR_SYNC_DRIFT \
+             VDE_HEALTH_OK VDE_HEALTH_MINOR VDE_HEALTH_MAJOR VDE_HEALTH_CRITICAL \
              VDE_LOCKS_DIR VDE_VM_LOCKS_DIR VDE_PORT_LOCKS_DIR \
              VDE_CONTAINER_SSH_PORT VDE_DOCKER_TIMEOUT VDE_SSH_TIMEOUT VDE_LOCK_TIMEOUT \
              VDE_MAX_PARALLEL_VMS VDE_PORT_PROBE_COOLDOWN \

--- a/lib/vde-errors
+++ b/lib/vde-errors
@@ -366,15 +366,23 @@ vde_error_map() {
     local info="${2:-}"
     
     case "${code}" in
-        ${VDE_ERR_NOT_FOUND:-2}) vde_error_vm_not_found "${info}" ;;
-        ${VDE_ERR_PERMISSION:-3}) vde_error_permission_denied "${info}" ;;
+        ${VDE_ERR_INVALID_INPUT:-2}) vde_error_show "Invalid Input" "Required arguments missing or malformed" "Check command syntax: vde <cmd> --help" ;;
+        ${VDE_ERR_NOT_FOUND:-3}) vde_error_vm_not_found "${info}" ;;
+        ${VDE_ERR_PERMISSION:-4}) vde_error_permission_denied "${info}" ;;
         ${VDE_ERR_TIMEOUT:-5}) vde_error_ssh_connection_failed "${info}" ;;
         ${VDE_ERR_EXISTS:-6}) vde_error_container_exists "${info}" ;;
+        ${VDE_ERR_DEPENDENCY:-7}) vde_error_show "Dependency Error" "A required tool or service is missing" "Ensure Docker and SSH are active: vde health" ;;
         ${VDE_ERR_DOCKER:-8}) vde_error_docker_build_failed "${info}" ;;
         ${VDE_ERR_LOCK:-9}) vde_error_show "Failed to acquire lock" "System timeout or kernel EEXIST" "Retry the command or check for deadlocks." ;;
         ${VDE_ERR_INVALID_DATA:-10}) vde_error_show "Invalid Data Structure" "JSON Schema validation failed" "Run 'vde validate' to fix the registry." ;;
+        ${VDE_ERR_CACHE_INVALID:-11}) vde_error_show "Cache Stale or Invalid" "The VM cache must be regenerated" "Run 'vde rebuild-cache' to synchronize." ;;
         ${VDE_ERR_LOCK_CONTENTION:-12}) vde_error_lock_contention "${info}" ;;
         ${VDE_ERR_SYNC_DRIFT:-13}) vde_error_sync_drift "${info}" ;;
+        
+        # --- HEALTH CHECK CODES (Rule 16) ---
+        ${VDE_HEALTH_MINOR:-30}) vde_log_warn "Health Check: Minor issues detected." "health" ;;
+        ${VDE_HEALTH_MAJOR:-31}) vde_log_error "Health Check: Major issues detected." "health" ;;
+        ${VDE_HEALTH_CRITICAL:-32}) vde_log_error "Health Check: Critical failure detected." "health" ;;
         
         # --- POSIX SIGNAL TRANSLATION (Rule 26 Hardening) ---
         130) vde_error_show "Operation Interrupted" "Received SIGINT (Ctrl+C)" "The operation was cancelled by the user. Some partial state may remain. Clean up with 'vde stop' if necessary." ;;


### PR DESCRIPTION
## Fracture Analysis
The recent audit and health checks identified several critical fractures:
- **Documentation Drift**: `available-scripts.md` was missing detailed core and maintenance script catalogs.
- **Error Engine Collision**: Exit code 3 was shared between `vde-health` (Critical Failure) and the centralized Error Engine (Unknown VM), causing confusing UX.
- **Security Hardening**: JupyterLab hydration contained a hardcoded fallback password.
- **Library Integrity**: `vde-naming` used direct `exit` calls, bypassing orchestrator control.
- **Logging Alignment**: `vde-health` utilized raw echo statements instead of structured logging.

## The Reforging
- **Gospel Restoration**: Updated `docs/available-scripts.md` with comprehensive catalogs for all Forge tools.
- **Exit Code De-collision**: Re-mapped `vde-health` to a unique range (30-39) and aligned `lib/vde-errors` with centralized constants.
- **Impurity Removal**: Purged hardcoded password from `jupyterlab-init.zsh`.
- **Library Decoupling**: Refactored `vde-naming` to return error codes instead of exiting.
- **Logging Standardization**: Aligned `vde-health` with the `vde_log_error` standard.

## The Beskar Set
- `docs/available-scripts.md`
- `scripts/setup/jupyterlab-init.zsh`
- `lib/vde-naming`
- `lib/vde-health`
- `lib/vde-constants`
- `lib/vde-errors`
- `bin/vde-health`

Closes #189, Closes #190, Closes #191, Closes #192, Closes #195

## Summary by Sourcery

Align vde health checks and error handling with centralized constants while addressing documentation and configuration drift.

Bug Fixes:
- Assign unique, non-colliding exit codes to vde-health and synchronize them with the centralized error engine.

Enhancements:
- Standardize vde-health logging to use the shared logging utilities instead of ad-hoc output.
- Refactor vde-naming to return error codes rather than exiting directly, improving orchestration control and library reuse.
- Remove hardcoded JupyterLab fallback password from the initialization script for stronger security posture.
- Expand available-scripts documentation with up-to-date catalogs for core and maintenance tools.

Documentation:
- Update docs/available-scripts.md to accurately document available Forge scripts and maintenance commands.