### PR TITLE
chore(core): codify tagging report mandate

### DIFF
--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -399,3 +399,4 @@ To build a database of feature ownership and shared laws, ALL artifacts (code, t
 - **Tests (BDD/Behave)**: Apply the tag at the Feature and Scenario levels.
 - **Documentation**: Include the tag in the metadata or section headers.
 - **Strikes**: Every PR and Issue MUST state its primary architectural tag in the body.
+- **Tagging Report**: For EVERY strike, you will produce an explicit Tagging Report listing each touched artifact and whether it is `@armor`, `@forge`, or `@shared-law` according to the Test of the Two Fires. This report MUST be recorded in the strike itself (PR/Issue body) as permanent documentation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,14 @@
 ### **IV. File Impact List (The Beskar Plates)**
 *List of files created or modified in this strike.*
 
-### **V. Refactoring Rationale (The Refiner's Fire)**
+### **V. Architectural Tagging Report (@armor | @forge | @shared-law)**
+> **MANDATE**: For EVERY strike, you MUST list each touched artifact and its classification according to the **Test of the Two Fires**.
+
+| Artifact | Classification | Justification |
+| :--- | :--- | :--- |
+| (Path) | `@armor` / `@forge` / `@shared-law` | (Brief reason) |
+
+### **VI. Refactoring Rationale (The Refiner's Fire)**
 *Explain why the code was structured this way. How does this strengthen the armor of the VDE?*
 
 ### **VI. Discussion Summary (The Signet's Record)**

--- a/docs/SOVEREIGN_CHARTER.md
+++ b/docs/SOVEREIGN_CHARTER.md
@@ -62,6 +62,8 @@ The relationship is hierarchical: **The Forge builds the Armor.**
     - **Forge Strike (@forge)**: Satisfies a universal requirement for governed development, "Any Thing" automation, or AI discipline (Governance Guard Audit).
     - **Shared-Law Strike (@shared-law)**: Modifies the foundational bridge or pillars used by both (Symbiotic Link Audit).
 
+4.  **The Tagging Report**: For EVERY strike, the agent MUST produce an explicit **Tagging Report** listing each touched artifact and its classification. This report is recorded in the permanent Chronicle (PR body) to build an empirical database of architectural ownership.
+
 ---
 
 **This is the Way.**


### PR DESCRIPTION
## Sovereign Reason
To ensure absolute architectural traceability, every strike must now document its impact through a standardized report.

## I. Architectural Tagging Report (@armor | @forge | @shared-law)
> **MANDATE**: For EVERY strike, you MUST list each touched artifact and its classification according to the **Test of the Two Fires**.

| Artifact | Classification | Justification |
| :--- | :--- | :--- |
| `.gemini/instructions.md` | `@forge` | Governance logic (Supreme Law). |
| `docs/SOVEREIGN_CHARTER.md` | `@shared-law` | Foundational covenant (Gospel pillar). |
| `.github/PULL_REQUEST_TEMPLATE.md` | `@forge` | Development ritual (Chronicle template). |

## II. The Reforging
- **Supreme Law**: Rule 24 now binds all future agents to produce this report.
- **Foundational Covenant**: The Sovereign Charter recognizes the report as essential for the Symbiotic Covenant.
- **Chronicle Ritual**: The PR template now enforces the report structure.

**Closes #236**

**Verdict**: Certified ✅ GREEN by Code-Reviewer.