### PR TITLE
fix(forge): implement GHOST PURGE and exclude .bak artifacts from audits

### DIFF
--- a/bin/check-zsh-shebang.zsh
+++ b/bin/check-zsh-shebang.zsh
@@ -43,6 +43,9 @@ done
 
 # Check library files in lib/
 for file in $(find lib -type f 2>/dev/null); do
+    # Skip backup files explicitly
+    [[ "${file}" == *".bak" ]] && continue
+
     shebang=$(head -1 "${file}" 2>/dev/null || true)
     
     if [[ "${shebang}" =~ ^#! ]]; then

--- a/bin/vde-enforce-uap.zsh
+++ b/bin/vde-enforce-uap.zsh
@@ -77,6 +77,11 @@ audit_file_content() {
     local file=$1
     local first_line
     
+    # Skip backup files explicitly
+    if [[ "$file" == *.bak ]]; then
+        return
+    fi
+    
     # Skip binary files
     if ! (file "$file" | grep -qE "text|JSON|XML|source"); then
         return

--- a/bin/vde-tactical-sweep.zsh
+++ b/bin/vde-tactical-sweep.zsh
@@ -79,5 +79,15 @@ if [[ -d "${VDE_ROOT_DIR}/.tmp" ]]; then
     vde_log_success "[SWEEP] Ephemeral artifacts purged." "sweep"
 fi
 
+# 6. THE GHOST PURGE: Remove all *.bak files recursively
+vde_log_info "[SWEEP] Purging all ghost files (*.bak)..." "sweep"
+local ghost_files=("${VDE_ROOT_DIR}"/**/*.bak(N))
+if [[ ${#ghost_files} -gt 0 ]]; then
+    rm -f "${ghost_files[@]}" 2>/dev/null
+    vde_log_success "[SWEEP] ${#ghost_files} ghost files purged." "sweep"
+else
+    vde_log_info "[SWEEP] No ghost files detected." "sweep"
+fi
+
 vde_log_success "[SWEEP] Tactical Sweep Complete. The Forge is Pristine." "sweep"
 exit ${VDE_SUCCESS}

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -30,8 +30,8 @@ done
 
 # 2. Secret Sentinel (Rule 12)
 # Regex-based search for hardcoded credentials (API_KEY, SECRET, PASSWORD) in staged changes.
-# Ignore files matching env.template and the env-files/ primer directory.
-staged_all=($(git diff --cached --name-only --diff-filter=ACM | grep -v "env.template" | grep -v "env-files/" || true))
+# Ignore files matching env.template, the env-files/ primer directory, and ghost files (*.bak).
+staged_all=($(git diff --cached --name-only --diff-filter=ACM | grep -v "env.template" | grep -v "env-files/" | grep -v "\.bak$" || true))
 
 for file in "${staged_all[@]}"; do
     if git diff --cached "$file" | grep -Ei "^[+].*(API_KEY|SECRET|PASSWORD)\s*=" > /dev/null 2>&1; then


### PR DESCRIPTION
## Fracture Analysis
Temporary .bak files were persisting after tests and triggering false UAP violations due to missing shebangs or ZSH-native flags.

## The Reforging
- **bin/vde-tactical-sweep.zsh**: Added "THE GHOST PURGE" to recursively remove all *.bak files.
- **bin/vde-enforce-uap.zsh** & **bin/check-zsh-shebang.zsh**: Updated to exclude *.bak files from compliance checks.
- **githooks/pre-commit**: Aligned to ignore .bak artifacts during security scans.

## The Beskar Set
- bin/vde-tactical-sweep.zsh
- bin/vde-enforce-uap.zsh
- bin/check-zsh-shebang.zsh
- githooks/pre-commit

Closes #252, #253

## Summary by Sourcery

Purge stray backup artifacts and exclude .bak files from automated audits and hooks.

Bug Fixes:
- Prevent false UAP and shebang compliance violations caused by lingering .bak backup files.

Enhancements:
- Extend the tactical sweep script to recursively delete .bak backup files and log the purge outcome.
- Update compliance and shebang-check scripts to explicitly ignore .bak backup files during analysis.
- Align the pre-commit hook behavior to ignore .bak artifacts during security-related checks.