### PR TITLE
[CHRONICLE] Healed vde init Structural Fracture

### DIFF
--- a/bin/generate-all-configs
+++ b/bin/generate-all-configs
@@ -277,16 +277,17 @@ main() {
     
     # Skip if already has config (unless --force)
     local config_file="${VDE_ROOT_DIR}/configs/docker/languages/${short_name}/docker-compose.yml"
-    if [[ -f "${config_file}" ]] && [[ "${FORCE_REGENERATE}" != "true" ]]; then
-      ((skipped_count++))
+    if [[ -f "${config_file}" && "${FORCE_REGENERATE}" != "true" ]]; then
+      (( skipped_count += 1 ))
+      (( env_skipped_count += 1 ))
       continue
     fi
 
     local pkgs="$(get_vm_info install "${short_name}" 2>/dev/null || echo "")"
     local custom_cmd="$(get_vm_info custom_cmd "${short_name}" 2>/dev/null || echo "")"
     generate_language_config "${short_name}" "${pkgs}" "${custom_cmd}"
-    ((generated_count++))
-    ((env_generated_count++))
+    (( generated_count += 1 ))
+    (( env_generated_count += 1 ))
   done
 
   # Process service VMs
@@ -295,16 +296,17 @@ main() {
     
     # Skip if already has config (unless --force)
     local config_file="${VDE_ROOT_DIR}/configs/docker/services/${short_name}/docker-compose.yml"
-    if [[ -f "${config_file}" ]] && [[ "${FORCE_REGENERATE}" != "true" ]]; then
-      ((skipped_count++))
+    if [[ -f "${config_file}" && "${FORCE_REGENERATE}" != "true" ]]; then
+      (( skipped_count += 1 ))
+      (( env_skipped_count += 1 ))
       continue
     fi
 
     local pkgs="$(get_vm_info install "${short_name}" 2>/dev/null || echo "")"
     local custom_cmd="$(get_vm_info custom_cmd "${short_name}" 2>/dev/null || echo "")"
     generate_service_config "${short_name}" "${pkgs}" "${custom_cmd}"
-    ((generated_count++))
-    ((env_generated_count++))
+    (( generated_count += 1 ))
+    (( env_generated_count += 1 ))
   done
 
   # Always generate SSH config (it's authoritative)

--- a/configs/ssh/config
+++ b/configs/ssh/config
@@ -1,8 +1,6 @@
-# VDE ARCHITECTURAL RECORD
-# @armor (Bridge Blueprint)
 # VDE (Virtual Development Environment) SSH Configuration
 # Sovereign Baseline: 1.4.1
-# Generated on Sun Apr 19 17:55:23 EDT 2026
+# Generated on Wed Apr 22 00:12:13 EDT 2026
 #
 # This file contains SSH config entries for all known language and service VMs.
 # Each VM type has a fixed SSH port assignment:
@@ -320,68 +318,4 @@ Host vde-jupyterlab
     UserKnownHostsFile ~/.ssh/vde/known_hosts
     ForwardAgent yes
     LogLevel ERROR
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
## Fracture Analysis
The [0;32m[SUCCESS] Technical Integrity Verified. The Armor is ready.[0m

╔════════════════════════════════════════════════════════════╗
║          VDE Initialization                              ║
╚════════════════════════════════════════════════════════════╝

Creating VDE directory structure...
  ✓ Directories created
Initializing environment files...
  ✓ .env already exists
Generating docker-compose configurations...
Generating missing docker-compose.yml and env files...


Generating SSH config...
Generated: /Users/dderyldowney/VDE/configs/ssh/config

=============================================================================
Docker configs: Generated 0, Skipped 31
Env files:       Generated 0, Skipped 31
SSH config:      Generated
=============================================================================
  ✓ Configurations generated
Finalizing SSH configuration...
  Priming SSH config from canonical artifact...
  ✓ SSH config primed
Building foundational vde-base image...
  ✓ vde-base image already exists
  ✓ Network 'vde-net' already exists
Setting file permissions...
  ✓ Permissions set
Installing VDE Git hooks...
  ✓ Git hooks installed
Registering default tech stack clusters...
  ✓ Default clusters registered

╔════════════════════════════════════════════════════════════╗
║          VDE Initialization Complete!                   ║
╚════════════════════════════════════════════════════════════╝


VDE Network Status:
===================
  vde-net: ✓ exists
  vde-testing: ✗ missing

Available networks:
vde-net flow was failing during config generation because Zsh returns exit code 1 for the post-increment operation  when  is 0. This triggered  and terminated the script prematurely.

## The Reforging
- Replaced all loop counters with , which is exit-code safe in Zsh.
- Corrected the  logic to ensure accurate reporting.
- Verified 100% success for [0;32m[SUCCESS] Technical Integrity Verified. The Armor is ready.[0m

╔════════════════════════════════════════════════════════════╗
║          VDE Initialization                              ║
╚════════════════════════════════════════════════════════════╝

Creating VDE directory structure...
  ✓ Directories created
Initializing environment files...
  ✓ .env already exists
Generating docker-compose configurations...
Generating missing docker-compose.yml and env files...


Generating SSH config...
Generated: /Users/dderyldowney/VDE/configs/ssh/config

=============================================================================
Docker configs: Generated 0, Skipped 31
Env files:       Generated 0, Skipped 31
SSH config:      Generated
=============================================================================
  ✓ Configurations generated
Finalizing SSH configuration...
  Priming SSH config from canonical artifact...
  ✓ SSH config primed
Building foundational vde-base image...
  ✓ vde-base image already exists
  ✓ Network 'vde-net' already exists
Setting file permissions...
  ✓ Permissions set
Installing VDE Git hooks...
  ✓ Git hooks installed
Registering default tech stack clusters...
  ✓ Default clusters registered

╔════════════════════════════════════════════════════════════╗
║          VDE Initialization Complete!                   ║
╚════════════════════════════════════════════════════════════╝


VDE Network Status:
===================
  vde-net: ✓ exists
  vde-testing: ✗ missing

Available networks:
vde-net in the BDD gateway tests.

## The Beskar Set
- Generating missing docker-compose.yml and env files...


Generating SSH config...
Generated: /Users/dderyldowney/VDE/configs/ssh/config

=============================================================================
Docker configs: Generated 0, Skipped 31
Env files:       Generated 0, Skipped 31
SSH config:      Generated
=============================================================================

Closes #262

## Summary by Sourcery

Fix VDE configuration generation script to be robust under Zsh loop semantics and ensure successful VDE initialization flow.

Bug Fixes:
- Prevent premature termination of the VDE config generation flow in Zsh by using exit-code-safe loop counters and correcting status reporting, stabilizing vde-net setup and related BDD gateway tests.

Build:
- Adjust VDE configuration generation script and SSH config artifacts used during local environment and docker-compose setup.