### PR TITLE
[CHRONICLE] Fix CodeQL Alert 7: Inefficient regular expression (ReDoS)

### DIFF
--- a/tests/scripts/generate_user_guide.py
+++ b/tests/scripts/generate_user_guide.py
@@ -227,7 +227,7 @@ def extract_scenarios_from_feature(content):
             feature_tags = [tag.strip() for tag in re.findall(r"@(\w+(?:-\w+)*)", tag_text)]
 
     # Pattern to match scenarios with optional tags before them
-    scenario_pattern = r"(?:((?:\s*@\w+(?:-\w+)*\n)+)*)\s*Scenario:\s*(.+?)\n((?:\s*(?:Given|When|Then|And)\s+.+(?:\n|$))+)"
+    scenario_pattern = r"((?:\s*@\w+(?:-\w+)*)*)\s*Scenario:\s*(.+?)\n((?:\s*(?:Given|When|Then|And)\s+.+(?:\n|$))+)"
     scenarios = []
     for match in re.finditer(scenario_pattern, content, re.MULTILINE):
         tag_block = match.group(1) or ""


### PR DESCRIPTION
## Fracture Analysis
CodeQL Alert #7 identified an inefficient regular expression (ReDoS) in `tests/scripts/generate_user_guide.py` with the pattern `(?:((?:\s*@\w+(?:-\w+)*\n)+)*)`. This allows for catastrophic backtracking.

## The Reforging
- Removed nested quantifier and replaced with deterministic, non-overlapping pattern `((?:\s*@\w+(?:-\w+)*)*)`.

## The Beskar Set
- `$VDE_ROOT/tests/scripts/generate_user_guide.py`

Closes #273