### PR TITLE
feat(governance): add automated review mandate for sourcery-ai

### DIFF
--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -118,6 +118,7 @@ Failure of any ritual constitutes a **Protocol Blockade**.
 * **R. The Clan Leader Authority (PR & Merge Gate)**:
     * The agent MAY make regular local commits on the active feature branch as needed to preserve a clear and incremental history.
     * The agent MUST obtain explicit written approval from the User (Clan Leader) before submitting, updating, or taking any action on a Pull Request, or performing any merge.
+    * **The Automated Review Mandate**: Once ANY PR, Issue, or commit has been pushed to GitHub, the agent MUST explicitly check for `sourcery-ai` comments or reviews. Sourcery-AI MUST be listened to, and the agent MUST immediately plan and execute remediations for any of its suggestions before proceeding to the Pre-Merge Halt.
     * **The Pre-Merge Halt**: When work on a branch is ready for review, the agent MUST:
         1. **Stop** all git and GitHub actions immediately.
         2. **Present** the following for the User's review:


### PR DESCRIPTION
## Fracture Analysis
The Clan Leader noticed that we committed directly to `develop` without a Signet/Chronicle pair when codifying the new `sourcery-ai` review mandate. That was a Creed violation. Furthermore, the mandate itself needs to be properly pushed and tracked.

## The Reforging
- Opened Signet #288 to track the mandate addition.
- Created branch `governance/automated-review-mandate`.
- Officially committed **The Automated Review Mandate** to `.gemini/instructions.md`, Section R.

## The Beskar Set
- `.gemini/instructions.md`

Closes #288

## Summary by Sourcery

Documentation:
- Add governance rule mandating explicit review of and remediation based on sourcery-ai comments and reviews on PRs, issues, and commits.