### PR TITLE
chore(dx): enable ANSI color output for Behave test runner

### DIFF
--- a/behave.ini
+++ b/behave.ini
@@ -7,6 +7,13 @@ tags = not wip
 verbose = False
 capture = True
 capture_stderr = True
+# Colorized step output (ANSI):
+#   executing  → grey   (currently running step)
+#   passed     → green
+#   failed     → red
+#   undefined  → yellow (warnings / skipped)
+color = always
+format = pretty
 # === Tag Taxonomy (NEW SCHEME) ===
 # FAST TESTS (No Docker Required)
 # @parser    = Natural language parser tests


### PR DESCRIPTION
## Fracture Analysis
Behave step output was monochrome in all contexts (terminal, pre-push hooks, subprocesses) because no color mode was explicitly configured. The default is \`auto\`, which suppresses ANSI codes when stdout is not a TTY.

## The Reforging
Added two settings to \`behave.ini\`:
- \`color = always\` — forces ANSI escape codes in all output contexts
- \`format = pretty\` — makes the formatter explicit (was implicitly default)

## Color Scheme (built into Behave's pretty formatter)
| Status | Color |
|---|---|
| Executing (current step) | Grey `\x1b[90m` |
| Passed | Green `\x1b[32m` |
| Failed | Red `\x1b[31m` |
| Undefined / Warning | Yellow `\x1b[33m` |

## The Beskar Set
- \`behave.ini\`

## Evidence
ANSI codes confirmed present in dry-run output (`cat -v` shows `^[[32m`, `^[[31m`, `^[[90m`, `^[[33m`).

Closes #315

## Summary by Sourcery

Configure Behave to always use colorized, pretty-formatted output for step execution.

Enhancements:
- Enable forced ANSI color output for Behave step results across all execution contexts by setting the color mode to always.
- Make the Behave pretty formatter explicit in configuration to standardize test output formatting.