### PR TITLE
fix(dx): change behave color=always to color=auto for CI safety

### DIFF
--- a/behave.ini
+++ b/behave.ini
@@ -12,7 +12,7 @@ capture_stderr = True
 #   passed     → green
 #   failed     → red
 #   undefined  → yellow (warnings / skipped)
-color = always
+color = auto
 format = pretty
 # === Tag Taxonomy (NEW SCHEME) ===
 # FAST TESTS (No Docker Required)


### PR DESCRIPTION
## Fracture Analysis
Sourcery flagged PR #316: \`color = always\` in \`behave.ini\` injects ANSI escape codes into all output contexts — CI logs, file redirects, and piped output — polluting machine-readable output. The pre-push hook invokes behave with \`--quiet --no-summary\`, so individual step colors are never shown there; \`always\` provided no benefit in that context.

## The Reforging
Changed \`color = always\` → \`color = auto\` in \`behave.ini\`.

\`auto\` uses TTY detection:
- **Interactive terminal** (user running tests manually) → colors active ✓
- **Pre-push hook / CI / piped output** (non-TTY) → clean plain text ✓

## The Beskar Set
- \`behave.ini\`

## Evidence
```
color: 'auto'   ← confirmed via behave.configuration.Configuration()
format: ['pretty']
```

Closes #317

## Summary by Sourcery

Enhancements:
- Change Behave configuration to use automatic color handling instead of always emitting colored output, keeping CI and non-TTY logs clean.