### PR TITLE
fix(core): remediate vde-info and vde-health diagnostic fractures

### DIFF
--- a/bin/vde-health
+++ b/bin/vde-health
@@ -385,7 +385,16 @@ vde_health_report_text() {
         local message="${parts[2]}"
         local triage="${parts[3]:-}"
         
-        local status_indicator
+        # Determine triage based on check type if parts length is higher
+        if [[ "${check}" == "memory" ]]; then
+            triage="${parts[3]:-}"
+        elif [[ "${check}" == "containers" ]]; then
+            # For containers: status|message|running|stopped|total
+            # No specific triage string, but we can synthesize one if unhealthy
+            [[ "${health_status}" == "MAJOR" ]] && triage="ADVICE: Check logs for unhealthy containers: 'vde logs <name>'"
+        fi
+        
+        local status_indicator=""
         case "${health_status}" in
             OK) status_indicator="[OK]" ;;
             MINOR) status_indicator="[MINOR]" ;;
@@ -396,7 +405,7 @@ vde_health_report_text() {
         
         echo "  ${status_indicator} ${check}"
         echo "         ${message}"
-        [[ -n "${triage}" ]] && echo "         \033[1;33m${triage}\033[0m"
+        [[ -n "${triage}" && "${triage}" != [0-9]# ]] && echo "         \033[1;33m${triage}\033[0m"
         echo ""
     done
     

--- a/bin/vde-info
+++ b/bin/vde-info
@@ -38,37 +38,58 @@ _VM_DISPLAY=""
 _SSH_PORT=""
 
 if [[ -n "${VM_STATE}" ]]; then
-    _VM_TYPE=$(_vde_extract_json_field "${VM_STATE}" "vm_type")
-    _VM_DISPLAY=$(_vde_extract_json_field "${VM_STATE}" "display")
-    _SSH_PORT=$(_vde_extract_json_field "${VM_STATE}" "ssh_port")
+    _VM_TYPE=$(echo "${VM_STATE}" | vde_query_json -r '.vm_type' 2>/dev/null)
+    _VM_DISPLAY=$(echo "${VM_STATE}" | vde_query_json -r '.display' 2>/dev/null)
+    _SSH_PORT=$(echo "${VM_STATE}" | vde_query_json -r '.ssh_port' 2>/dev/null)
 fi
 
 # Fallback or refresh if missing
-[[ -z "${_VM_TYPE}" ]] && _VM_TYPE=$(get_vm_type "${RESOLVED_NAME}")
-[[ -z "${_VM_DISPLAY}" ]] && _VM_DISPLAY=$(get_vm_display "${RESOLVED_NAME}")
+[[ -z "${_VM_TYPE}" || "${_VM_TYPE}" == "null" ]] && _VM_TYPE=$(get_vm_type "${RESOLVED_NAME}")
+[[ -z "${_VM_DISPLAY}" || "${_VM_DISPLAY}" == "null" ]] && _VM_DISPLAY=$(get_vm_display "${RESOLVED_NAME}")
 VM_STATUS=$(vm_container_status "${RESOLVED_NAME}" 2>/dev/null || echo "not created")
 CONTAINER=$(vde_get_container_name "${RESOLVED_NAME}")
 HOSTNAME=$(vde_get_hostname "${RESOLVED_NAME}")
 
-# If container is running, always refresh SSH port from Docker to be sure
+# Safe Port Discovery (Hardened against set -e and template errors)
 if [[ "${VM_STATUS}" == "running" ]]; then
-    _SSH_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}' "${CONTAINER}" 2>/dev/null)
+    # 1. Try to find the host port mapped to the container's designated SSH port
+    local internal_port=$(get_vm_ssh_port "${RESOLVED_NAME}" 2>/dev/null || echo "22")
+    # If it is a service Spoke like postgres, it might be listening on its own port
+    # but VDE usually maps host_port:22 or host_port:internal_ssh_port
+    
+    # Attempt extraction without tripping set -e
+    local docker_port_json
+    docker_port_json=$(docker inspect --format='{{json .NetworkSettings.Ports}}' "${CONTAINER}" 2>/dev/null) || docker_port_json="{}"
+    
+    # Try 22/tcp first (VDE Standard)
+    _SSH_PORT=$(echo "${docker_port_json}" | vde_query_json -r '.["22/tcp"][0].HostPort' 2>/dev/null)
+    
+    # If empty, try the internal port from registry
+    if [[ -z "${_SSH_PORT}" || "${_SSH_PORT}" == "null" ]]; then
+        _SSH_PORT=$(echo "${docker_port_json}" | vde_query_json -r ".[\"${internal_port}/tcp\"][0].HostPort" 2>/dev/null)
+    fi
 fi
 
-# Try to get SSH port from registry if still empty
-[[ -z "${_SSH_PORT}" || "${_SSH_PORT}" == "0" ]] && _SSH_PORT=$(get_vm_ssh_port "${RESOLVED_NAME}" 2>/dev/null)
+# 2. Try to get SSH port from registry if still empty or container not running
+if [[ -z "${_SSH_PORT}" || "${_SSH_PORT}" == "null" || "${_SSH_PORT}" == "0" ]]; then
+    _SSH_PORT=$(get_vm_ssh_port "${RESOLVED_NAME}" 2>/dev/null || echo "")
+fi
 
 # Final Fallback
-[[ -z "${_SSH_PORT}" ]] && _SSH_PORT="not assigned"
+[[ -z "${_SSH_PORT}" || "${_SSH_PORT}" == "null" ]] && _SSH_PORT="not assigned"
 
 # Update state if it was missing or stale
 if [[ -z "${VM_STATE}" ]] || [[ "${VM_STATUS}" == "running" ]]; then
+    # Ensure _SSH_PORT is numeric for JSON or "null"
+    local json_port="${_SSH_PORT}"
+    [[ "${json_port}" =~ ^[0-9]+$ ]] || json_port="null"
+
     NEW_STATE=$(cat <<EOF
 {
   "vm_name": "${RESOLVED_NAME}",
   "vm_type": "${_VM_TYPE}",
   "display": "${_VM_DISPLAY}",
-  "ssh_port": ${_SSH_PORT},
+  "ssh_port": ${json_port},
   "status": "${VM_STATUS}",
   "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }


### PR DESCRIPTION
## Fracture Analysis
The diagnostic tools were found to be non-operational under Hub resource pressure:
1. `vde-info` contained a `set -e` trap that triggered on missing SSH port mappings (common in postgres and other service Spokes using non-22 internal ports).
2. `vde-health` suffered from field mapping misalignments in the text report loop, causing data leaks and garbled messages.

## The Reforging
- **`bin/vde-info`**: Refactored to use `vde_query_json` with safe extraction. Added logic to detect host port mappings for both standard (22) and registry-defined internal SSH ports.
- **`bin/vde-health`**: Corrected the report loop to accurately map health status and triage messages. Removed raw output leaks.

## The Beskar Set
- `bin/vde-info`
- `bin/vde-health`

Closes #321

## Summary by Sourcery

Fix and harden VDE diagnostic scripts to behave correctly under hub resource pressure and produce accurate, sanitized health information.

Bug Fixes:
- Prevent vde-info from failing when SSH port mappings are missing or use non-standard internal ports.
- Correct vde-health report field mappings to eliminate data leaks and garbled health messages.

Enhancements:
- Use JSON-based querying and safer extraction in vde-info while automatically detecting SSH host port mappings for both standard and registry-defined ports.
- Align vde-health status and triage reporting to generate clear, structured diagnostic output without exposing raw data.