### PR TITLE
fix(core): remediate POSTGRES_DEV_PASSWORD precedence and .env hierarchy

### DIFF
--- a/bin/vde
+++ b/bin/vde
@@ -170,8 +170,13 @@ case ${ACTION} in
             fi
 
             # Canonical Ignition Handshake
+            local vm_env_file
+            vm_env_file=$(get_vm_env_file "${CANONICAL_NAME}")
+            
             local -a compose_up_cmd=(docker compose -f "${compose_file}")
             [[ -f "${VDE_ROOT_DIR}/.env" ]] && compose_up_cmd+=(--env-file "${VDE_ROOT_DIR}/.env")
+            [[ -f "${VDE_ROOT_DIR}/${vm_env_file}" ]] && compose_up_cmd+=(--env-file "${VDE_ROOT_DIR}/${vm_env_file}")
+            
             compose_up_cmd+=(up -d)
 
             if vde_run "${CANONICAL_NAME}" "${compose_up_cmd[@]}" >/dev/null 2>&1; then

--- a/bin/vde-rebuild
+++ b/bin/vde-rebuild
@@ -167,10 +167,14 @@ build_vm_image() {
     echo "Rebuilding ${canonical_name}..."
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     
-    # Export required variables for hardening
-    export POSTGRES_DEV_PASSWORD="${POSTGRES_DEV_PASSWORD}"
+    # Resolve Spoke-specific env file (Rule 4.1)
+    local vm_env_file
+    vm_env_file=$(get_vm_env_file "${canonical_name}")
+
     local -a build_cmd=(docker compose -f "${compose_file}")
     [[ -f "${VDE_ROOT_DIR}/.env" ]] && build_cmd+=(--env-file "${VDE_ROOT_DIR}/.env")
+    [[ -f "${VDE_ROOT_DIR}/${vm_env_file}" ]] && build_cmd+=(--env-file "${VDE_ROOT_DIR}/${vm_env_file}")
+    
     build_cmd+=(build)
     [[ "${NOCACHE}" == "true" ]] && build_cmd+=(--no-cache)
     


### PR DESCRIPTION
# 🛡️ The Reforging: Signet #328

### **1. Fracture Analysis (Sovereign Reason)**
The PostgreSQL Spoke was failing to ignite with a Rule 12 Violation. The POSTGRES_DEV_PASSWORD was being shadowed by an empty string because bin/vde-rebuild explicitly exported the variable before docker compose could load it from the root .env. Furthermore, the system lacked a proper hierarchical .env loading strategy, preventing Spoke-specific overrides from being correctly interpolated.

### **2. The Reforging (The Fix)**
- **Shadow Purge**: Removed the problematic export in bin/vde-rebuild to allow docker compose to handle variable priority.
- **Hierarchical Alignment**: Implemented sequential .env loading (root then spoke-specific) in both bin/vde and bin/vde-rebuild using the --env-file flag.
- **Validation**: Verified with a manual vde rebuild postgres --no-cache and a full Proof of Life heartbeat.

### **3. The Beskar Set (Involved Files)**
- bin/vde
- bin/vde-rebuild

### **4. Final Architectural Tagging Report**
| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| bin/vde | @armor | .env hierarchy enforcement (Project 1) |
| bin/vde-rebuild | @armor | Environment precedence remediation (Project 1) |

Closes #328

## Summary by Sourcery

Fix PostgreSQL development environment startup by correcting environment variable precedence and introducing a consistent .env loading hierarchy for vde commands.

Bug Fixes:
- Resolve POSTGRES_DEV_PASSWORD being overridden by an empty value during vde rebuild, allowing docker compose to receive the correct password from .env files.

Enhancements:
- Introduce ordered .env loading (root then spoke-specific) for vde and vde-rebuild using explicit env-file configuration to standardize environment overrides.