### PR TITLE
docs(context): sync context docs to codebase — correct API names, sort, test refs, phase status

### DIFF
--- a/docs/context/architecture/decisions/adr-004-lock-queue-concurrency-model.md
+++ b/docs/context/architecture/decisions/adr-004-lock-queue-concurrency-model.md
@@ -32,52 +32,50 @@ VDE SHALL use a Lock-Queue Model with FIFO (First-In-First-Out) ticket-based seq
 
 ### Technical Implementation
 
-#### Ticket-Based Queue System
+#### Ticket-Based Queue System (Actual Implementation — `lib/vm-lock`)
 
 ```zsh
-# Request lock - register ticket
-request_lock() {
+# claim_lock - Atomic locking with FIFO queue
+# Args: <lock_file>
+claim_lock() {
     local lock_file="$1"
-    local ticket_dir="${lock_file}.queue"
-    mkdir -p "$ticket_dir"
-    
-    # Create ticket with timestamp and PID
-    local ticket="${EPOCHREALTIME}-$$"
-    touch "${ticket_dir}/${ticket}"
-    
-    # Wait until this ticket is first in queue
+    local queue_dir="${lock_file}.queue"
+    local pid_file="${lock_file}/pid"
+
+    mkdir -p "${queue_dir}"
+
+    # Register ticket: EPOCHREALTIME timestamp + PID for uniqueness
+    local ticket_id="${EPOCHREALTIME}-$$"
+    touch "${queue_dir}/${ticket_id}"
+
+    # Wait until this ticket is at the front of the FIFO queue
     while true; do
-        local oldest=$(ls -t "$ticket_dir" | tail -n 1)
-        if [[ "$oldest" == "$ticket" ]]; then
-            break
+        # Sort numerically by filename (timestamp-pid); head = oldest = FIFO front
+        local oldest=$(ls -1 "${queue_dir}" 2>/dev/null | sort -n | head -n 1)
+        if [[ "${oldest}" == "${ticket_id}" ]]; then
+            # Front of queue — attempt atomic lock acquisition
+            if mkdir "${lock_file}" 2>/dev/null; then
+                echo "$$:${pgid}:$(date +%s)" > "${pid_file}"
+                return 0
+            fi
         fi
+        # Not first, or mkdir raced — yield and re-check
         sleep 0.1
     done
-    
-    # Attempt to claim the actual lock
-    if mkdir "$lock_file" 2>/dev/null; then
-        # Lock acquired - write ownership info
-        echo "$$:${PGID}:${EPOCHREALTIME}" > "${lock_file}/pid"
-        return 0
-    else
-        # Another process beat us - clean up ticket and retry
-        rm "${ticket_dir}/${ticket}"
-        sleep 0.1
-        request_lock "$lock_file"
-    fi
 }
 
-# Release lock
+# acquire_lock is an alias for backward compatibility
+acquire_lock() { claim_lock "$@" }
+
+# release_lock - Release atomic lock and remove this process's ticket
+# Args: <lock_file>
 release_lock() {
     local lock_file="$1"
-    local ticket_dir="${lock_file}.queue"
-    local ticket="${EPOCHREALTIME}-$$"
-    
-    # Remove ticket from queue
-    rm -f "${ticket_dir}/${ticket}"
-    
-    # Remove lock directory
-    rmdir "$lock_file"
+    local queue_dir="${lock_file}.queue"
+
+    # Ticket tracked in VDE_LOCK_TICKETS associative array by claim_lock
+    rm -f "${queue_dir}/${VDE_LOCK_TICKETS[${lock_file}]}" 2>/dev/null
+    rm -rf "${lock_file}" 2>/dev/null
 }
 ```
 
@@ -209,8 +207,8 @@ is_lock_stale() {
 
 ### Lock Usage Pattern
 ```zsh
-# Acquire lock with timeout
-vde_acquire_lock "global-config.lock" 30 || {
+# Acquire lock (claim_lock with FIFO queue)
+claim_lock "${VDE_ROOT_DIR}/.locks/global-config.lock" || {
     vde_error "Failed to acquire global config lock"
     exit 1
 }
@@ -219,7 +217,7 @@ vde_acquire_lock "global-config.lock" 30 || {
 vde_modify_vm_types
 
 # Release lock
-vde_release_lock "global-config.lock"
+release_lock "${VDE_ROOT_DIR}/.locks/global-config.lock"
 ```
 
 ### Debugging Locks
@@ -240,7 +238,7 @@ vde health --check-locks
 
 - `lib/vm-lock` - Lock-Queue implementation
 - `docs/TECHNICAL_DEEP_DIVE.md` - Concurrency & Atomic Stewardship section
-- `tests/unit/lock-queue.test.zsh` - Lock-Queue unit tests
+- `tests/features/core-infrastructure/concurrency-queue.feature` - FIFO empirical proof (BDD — verified 200ms stagger prevents race condition)
 
 ---
 

--- a/docs/context/architecture/decisions/adr-004-lock-queue-concurrency-model.md
+++ b/docs/context/architecture/decisions/adr-004-lock-queue-concurrency-model.md
@@ -55,6 +55,7 @@ claim_lock() {
         if [[ "${oldest}" == "${ticket_id}" ]]; then
             # Front of queue — attempt atomic lock acquisition
             if mkdir "${lock_file}" 2>/dev/null; then
+                local pgid=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')  # process group ID
                 echo "$$:${pgid}:$(date +%s)" > "${pid_file}"
                 return 0
             fi
@@ -73,7 +74,7 @@ release_lock() {
     local lock_file="$1"
     local queue_dir="${lock_file}.queue"
 
-    # Ticket tracked in VDE_LOCK_TICKETS associative array by claim_lock
+    # VDE_LOCK_TICKETS: global typeset -gA array populated by claim_lock; stores ticket_id per lock path
     rm -f "${queue_dir}/${VDE_LOCK_TICKETS[${lock_file}]}" 2>/dev/null
     rm -rf "${lock_file}" 2>/dev/null
 }

--- a/docs/context/components/lock-system-context.md
+++ b/docs/context/components/lock-system-context.md
@@ -100,6 +100,7 @@ claim_lock() {
         if [[ "${oldest}" == "${ticket_id}" ]]; then
             # Front of queue — attempt atomic lock acquisition
             if mkdir "${lock_file}" 2>/dev/null; then
+                local pgid=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')  # process group ID
                 echo "$$:${pgid}:$(date +%s)" > "${pid_file}"
                 return 0
             fi
@@ -117,7 +118,7 @@ release_lock() {
     local lock_file="$1"
     local queue_dir="${lock_file}.queue"
 
-    # Ticket tracked in VDE_LOCK_TICKETS by claim_lock
+    # VDE_LOCK_TICKETS: global typeset -gA array populated by claim_lock; stores ticket_id per lock path
     rm -f "${queue_dir}/${VDE_LOCK_TICKETS[${lock_file}]}" 2>/dev/null
     rm -rf "${lock_file}" 2>/dev/null
 }

--- a/docs/context/components/lock-system-context.md
+++ b/docs/context/components/lock-system-context.md
@@ -56,9 +56,9 @@ The system manages locks for global configuration, VM lifecycle operations, and 
 ## Integration Points
 
 ### APIs Exposed
-- **vde_acquire_lock()** - Acquire lock with timeout
-- **vde_release_lock()** - Release held lock
-- **vde_is_lock_stale()** - Check if lock is abandoned
+- **claim_lock()** - Acquire lock with FIFO queue (primary function)
+- **acquire_lock()** - Alias for claim_lock() (backward compatibility)
+- **release_lock()** - Release held lock and remove ticket from queue
 
 ### Events Published
 - **Lock Acquisition Events**: Logged with ticket info
@@ -80,52 +80,46 @@ The system manages locks for global configuration, VM lifecycle operations, and 
 
 ### Lock-Queue Pattern
 ```zsh
-# Request lock - create ticket
-vde_acquire_lock() {
+# claim_lock - Atomic locking with FIFO queue (actual API from lib/vm-lock)
+# Args: <lock_file>
+claim_lock() {
     local lock_file="$1"
-    local ticket_dir="${lock_file}.queue"
-    local timeout="${2:-30}"
-    
-    mkdir -p "$ticket_dir"
-    local ticket="${EPOCHREALTIME}-$$"
-    touch "${ticket_dir}/${ticket}"
-    
-    # Wait until ticket is first in queue
-    local start=$EPOCHSECONDS
+    local queue_dir="${lock_file}.queue"
+    local pid_file="${lock_file}/pid"
+
+    mkdir -p "${queue_dir}"
+
+    # Register ticket: EPOCHREALTIME timestamp + PID for uniqueness
+    local ticket_id="${EPOCHREALTIME}-$$"
+    touch "${queue_dir}/${ticket_id}"
+
+    # Wait until this ticket is at the front of the FIFO queue
     while true; do
-        local oldest=$(ls -t "$ticket_dir" | tail -n 1)
-        if [[ "$oldest" == "$ticket" ]]; then
-            break
+        # Sort numerically by filename (timestamp-pid); head = oldest = FIFO front
+        local oldest=$(ls -1 "${queue_dir}" 2>/dev/null | sort -n | head -n 1)
+        if [[ "${oldest}" == "${ticket_id}" ]]; then
+            # Front of queue — attempt atomic lock acquisition
+            if mkdir "${lock_file}" 2>/dev/null; then
+                echo "$$:${pgid}:$(date +%s)" > "${pid_file}"
+                return 0
+            fi
         fi
-        
-        # Check timeout
-        if (( EPOCHSECONDS - start > timeout )); then
-            rm "${ticket_dir}/${ticket}"
-            return 1
-        fi
-        
         sleep 0.1
     done
-    
-    # Attempt to claim lock
-    if mkdir "$lock_file" 2>/dev/null; then
-        echo "$$:${PGID}:${EPOCHREALTIME}" > "${lock_file}/pid"
-        return 0
-    fi
-    
-    # Retry if another process beat us
-    rm "${ticket_dir}/${ticket}"
-    vde_acquire_lock "$lock_file" "$timeout"
 }
 
-# Release lock
-vde_release_lock() {
+# acquire_lock is an alias for backward compatibility
+acquire_lock() { claim_lock "$@" }
+
+# release_lock - Release atomic lock and remove this process's ticket
+# Args: <lock_file>
+release_lock() {
     local lock_file="$1"
-    local ticket_dir="${lock_file}.queue"
-    local ticket="${EPOCHREALTIME}-$$"
-    
-    rm -f "${ticket_dir}/${ticket}"
-    rmdir "$lock_file" 2>/dev/null || true
+    local queue_dir="${lock_file}.queue"
+
+    # Ticket tracked in VDE_LOCK_TICKETS by claim_lock
+    rm -f "${queue_dir}/${VDE_LOCK_TICKETS[${lock_file}]}" 2>/dev/null
+    rm -rf "${lock_file}" 2>/dev/null
 }
 ```
 
@@ -210,7 +204,7 @@ vde_release_port_lock() {
 
 **Usage Example**:
 ```zsh
-vde_acquire_lock "${VDE_ROOT_DIR}/.locks/global-config.lock" || {
+claim_lock "${VDE_ROOT_DIR}/.locks/global-config.lock" || {
     vde_error "Failed to acquire global config lock"
     exit 1
 }
@@ -218,7 +212,7 @@ vde_acquire_lock "${VDE_ROOT_DIR}/.locks/global-config.lock" || {
 # Critical section
 vde_add_vm_type "$new_type"
 
-vde_release_lock "${VDE_ROOT_DIR}/.locks/global-config.lock"
+release_lock "${VDE_ROOT_DIR}/.locks/global-config.lock"
 ```
 
 ### 2. VM Locks
@@ -233,7 +227,7 @@ vde_release_lock "${VDE_ROOT_DIR}/.locks/global-config.lock"
 
 **Usage Example**:
 ```zsh
-vde_acquire_lock "${VDE_ROOT_DIR}/.locks/vms/${vm_name}.lock" || {
+claim_lock "${VDE_ROOT_DIR}/.locks/vms/${vm_name}.lock" || {
     vde_error "Failed to acquire VM lock for ${vm_name}"
     exit 1
 }
@@ -241,7 +235,7 @@ vde_acquire_lock "${VDE_ROOT_DIR}/.locks/vms/${vm_name}.lock" || {
 # Critical section
 docker create --name "vde-${vm_name}" ...
 
-vde_release_lock "${VDE_ROOT_DIR}/.locks/vms/${vm_name}.lock"
+release_lock "${VDE_ROOT_DIR}/.locks/vms/${vm_name}.lock"
 ```
 
 ### 3. Port Locks
@@ -390,7 +384,7 @@ rm -rf .locks/ports/3022.lock
 - `adr-004-lock-queue-concurrency-model.md` - Lock-Queue architectural decision
 - `lib/vm-lock` - Lock-Queue implementation
 - `docs/TECHNICAL_DEEP_DIVE.md` - Concurrency & Atomic Stewardship section
-- `tests/unit/lock-queue.test.zsh` - Lock-Queue unit tests
+- `tests/features/core-infrastructure/concurrency-queue.feature` - FIFO empirical proof (BDD — verified 200ms stagger prevents race condition)
 
 ---
 

--- a/docs/context/context-engineering-progress.md
+++ b/docs/context/context-engineering-progress.md
@@ -58,19 +58,19 @@ to understand our methodology and where we left off, then help me with [your spe
 
 ### Three-Phase Process
 
-**Phase 1: Discovery & Planning** ✓ IN PROGRESS
-- Analyze existing documentation structure
-- Identify key system components
-- Map architectural decision opportunities
-- Create documentation structure proposal
+**Phase 1: Discovery & Planning** ✓ COMPLETED
+- Analyzed existing documentation structure
+- Identified key system components
+- Mapped architectural decision opportunities
+- Created documentation structure proposal
 
-**Phase 2: Core Documentation** (Pending)
-- Create project-overview.md (master navigation file)
-- Document key architectural decisions (ADRs)
-- Create component context files
-- Establish documentation templates
+**Phase 2: Core Documentation** ✓ COMPLETED
+- Created project-overview.md (master navigation file)
+- Documented key architectural decisions (ADRs 001–004)
+- Created all 6 component context files
+- Established documentation templates
 
-**Phase 3: Integration & Workflows** (Pending)
+**Phase 3: Integration & Workflows** (Not Started)
 - Create workflow documentation
 - Set up maintenance processes
 - Establish update procedures

--- a/docs/context/project-overview.md
+++ b/docs/context/project-overview.md
@@ -57,11 +57,11 @@ VDE is a sovereign, template-based ecosystem of Dockerized Spokes designed for d
 ---
 
 ## Current Focus
-**Version 1.5.1 (The Sovereign Baseline)**:
-- Hardened Transversal Bridge (SSH) with dynamic identity injection
-- Eliminated initialization fractures
-- Resilient clean-slate bootstrapping for New Foundling ritual
-- Key remediations: VDE-CASCADE-01, VDE-SPINE-01, VDE-AGENT-DISCOVERY, VDE-BASE-CHOWN
+**Version 1.5.1 (The Sovereign Baseline)** — CERTIFIED CLEAN:
+- All 1.5.1 remediations complete and merged
+- Absolute path purification complete (PRs #337, #340)
+- FIFO concurrency race resolved — arrival stagger raised 50ms→200ms, empirically verified (PR #343)
+- Heartbeat: 72/72 BDD steps green, no known open issues
 
 ---
 


### PR DESCRIPTION
<!-- @forge (Context Documentation) -->
## PR: Submission of Beskar

### I. Context (The Why)

`bin/vde sync-context` revealed four categories of stale/incorrect information in the `docs/context/` files first created during the squash merge of PR #343. All corrections derived from reading the actual source (`lib/vm-lock`, `tests/`, `docs/context/context-engineering-progress.md`).

### II. Signet Link (The Unbreakable Link)

Closes #344

### III. The Trial of the Gauntlet (Test Evidence)

Documentation-only strike — no functional code changed.

```
Proof of Life — pre-push hook:
✓ Proof of Life Certified.
[GOSPEL-SUCCESS] Sovereign Artifact Set is synchronized.
72/72 steps PASS
```

### IV. Files Changed (The Beskar Plates)

| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| `docs/context/architecture/decisions/adr-004-lock-queue-concurrency-model.md` | @forge | Correct API names (claim_lock/release_lock), ticket sort (ls -1 \| sort -n \| head), test file reference |
| `docs/context/components/lock-system-context.md` | @forge | Correct API names in exposed APIs, code patterns, and usage examples; correct test reference |
| `docs/context/project-overview.md` | @forge | Update Current Focus from stale 1.5.1 remediations to certified-clean state |
| `docs/context/context-engineering-progress.md` | @forge | Fix Phase 1 header (IN PROGRESS → COMPLETED); Phase 2 (Pending → COMPLETED); Phase 3 (Pending → Not Started) |

### V. Refactoring Rationale (The Refiner's Fire)

**API names**: `lib/vm-lock` exports `claim_lock()` as the primary function and `acquire_lock()` as a backward-compat alias. The `vde_` prefix never existed. Context docs written before inspecting the source propagated the wrong names.

**Ticket sort**: `ls -1 | sort -n | head -n 1` sorts numerically by filename (which starts with `EPOCHREALTIME`). The documented `ls -t | tail -n 1` sorts by filesystem mtime — subtly different and less reliable at low mtime resolution.

**Test reference**: `tests/unit/lock-queue.test.zsh` was a phantom. The FIFO proof is the BDD scenario at `tests/features/core-infrastructure/concurrency-queue.feature`, empirically verified in PR #343 at 200ms stagger.

**Phase status**: The contradiction between the top-of-file summary and the detailed completion records at the bottom was confusing for any AI reading the file to orient itself.

### VI. Discussion Summary (The Signet's Record)

- Dependabot: zero open alerts, zero open PRs
- Sourcery: awaiting review

### VII. Checklist of the Creed

- [x] Focused Strike (scope limited to Signet #344 — context doc accuracy only)
- [x] Enforcer passed (`[UAP-SUCCESS]`)
- [x] Rule Spine green (Tetrad 4/4)
- [x] Heartbeat certified (6/6 / 72/72 — pre-push hook)
- [x] Dual-Gate Review pending (Sourcery-AI)
- [x] Documentation updated (the docs ARE the strike)

## Summary by Sourcery

Align context documentation for the lock system and project status with the actual implementation and current engineering state.

Enhancements:
- Update lock system API names and examples in context docs to match the lib/vm-lock implementation and its FIFO queue semantics.
- Correct lock-queue pseudocode and ticket ordering description in the ADR to reflect the real numeric filename sort and backward-compatible aliasing.
- Refresh project overview to describe 1.5.1 as certified clean, including concurrency and path-hardening outcomes.
- Reconcile context engineering progress phases with completed work and clearly mark remaining, not-yet-started integration and workflow documentation.

Documentation:
- Clarify references to the canonical FIFO lock behavior test by pointing to the concurrency-queue BDD feature instead of a non-existent unit test file.