### PR TITLE
fix(tests): remediate Docker container leaks in BDD suite

### DIFF
--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -95,19 +95,23 @@ def after_all(context):
         shutil.rmtree(context.temp_dir)
 
 
+def _cleanup_feature_containers(tags):
+    """Purge containers associated with specific feature tags."""
+    if "dns" in tags:
+        for container in ["vde-python", "vde-postgres"]:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
+    if "jupyterlab" in tags:
+        subprocess.run(["docker", "rm", "-f", "vde-jupyterlab"], capture_output=True, check=False)
+
+
 def before_feature(context, feature):
     """Trigger cleanup for pristine features."""
     if "pristine" in feature.tags:
         sweep_script = os.path.join(VDE_ROOT, "bin/vde-tactical-sweep.zsh")
         if os.path.exists(sweep_script):
             subprocess.run([sweep_script], check=False)
-    # Ensure clean state so dns features start with no leftover spokes
-    if "dns" in feature.tags:
-        for container in ["vde-python", "vde-postgres"]:
-            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
-    # Ensure clean state so jupyterlab features start with no leftover spokes
-    if "jupyterlab" in feature.tags:
-        subprocess.run(["docker", "rm", "-f", "vde-jupyterlab"], capture_output=True, check=False)
+    
+    _cleanup_feature_containers(feature.tags)
 
 
 def after_feature(context, feature):
@@ -116,13 +120,8 @@ def after_feature(context, feature):
         sweep_script = os.path.join(VDE_ROOT, "bin/vde-tactical-sweep.zsh")
         if os.path.exists(sweep_script):
             subprocess.run([sweep_script], check=False)
-    # Force-remove spokes started by dns features so they cannot cascade into Rule K for later features
-    if "dns" in feature.tags:
-        for container in ["vde-python", "vde-postgres"]:
-            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
-    # Force-remove spokes started by jupyterlab features
-    if "jupyterlab" in feature.tags:
-        subprocess.run(["docker", "rm", "-f", "vde-jupyterlab"], capture_output=True, check=False)
+    
+    _cleanup_feature_containers(feature.tags)
 
 
 def before_scenario(context, scenario):

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -101,6 +101,13 @@ def before_feature(context, feature):
         sweep_script = os.path.join(VDE_ROOT, "bin/vde-tactical-sweep.zsh")
         if os.path.exists(sweep_script):
             subprocess.run([sweep_script], check=False)
+    # Ensure clean state so dns features start with no leftover spokes
+    if "dns" in feature.tags:
+        for container in ["vde-python", "vde-postgres"]:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
+    # Ensure clean state so jupyterlab features start with no leftover spokes
+    if "jupyterlab" in feature.tags:
+        subprocess.run(["docker", "rm", "-f", "vde-jupyterlab"], capture_output=True, check=False)
 
 
 def after_feature(context, feature):
@@ -109,6 +116,13 @@ def after_feature(context, feature):
         sweep_script = os.path.join(VDE_ROOT, "bin/vde-tactical-sweep.zsh")
         if os.path.exists(sweep_script):
             subprocess.run([sweep_script], check=False)
+    # Force-remove spokes started by dns features so they cannot cascade into Rule K for later features
+    if "dns" in feature.tags:
+        for container in ["vde-python", "vde-postgres"]:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
+    # Force-remove spokes started by jupyterlab features
+    if "jupyterlab" in feature.tags:
+        subprocess.run(["docker", "rm", "-f", "vde-jupyterlab"], capture_output=True, check=False)
 
 
 def before_scenario(context, scenario):

--- a/tests/features/steps/chaos_steps.py
+++ b/tests/features/steps/chaos_steps.py
@@ -68,6 +68,7 @@ echo "Simulated apt artifacts created."
     with open("scripts/setup/chaos-init.zsh", "w") as f:
         f.write(content)
     os.chmod("scripts/setup/chaos-init.zsh", 0o755)
+    context.add_cleanup(lambda: os.remove("scripts/setup/chaos-init.zsh") if os.path.exists("scripts/setup/chaos-init.zsh") else None)
 
 @given(u'a VM "vde-chaos" registered with this script')
 def step_impl(context):
@@ -78,6 +79,12 @@ def step_impl(context):
         f.write("lang|chaos|chaos|Chaos VM|curl|zsh /vde/scripts/setup/chaos-init.zsh||2299\n")
     # Force re-smelt
     subprocess.run(["zsh", "-c", "bin/vde-matrix-rebuild.zsh --quiet"])
+
+    def _restore_conf():
+        if hasattr(context, 'conf_bak') and os.path.exists(context.conf_bak):
+            subprocess.run(["mv", context.conf_bak, "data/vm-types.conf"])
+            subprocess.run(["zsh", "-c", "bin/vde-matrix-rebuild.zsh --quiet"])
+    context.add_cleanup(_restore_conf)
 
 @when(u'I execute "vde create chaos"')
 def step_impl(context):

--- a/tests/features/steps/chaos_steps.py
+++ b/tests/features/steps/chaos_steps.py
@@ -101,10 +101,3 @@ def step_impl(context):
     # We expect to see the 'partial' directory listed.
     assert "Rule 12.5 Violation - apt artifacts found in /var/lib/apt/lists/" in context.res.stdout or "Rule 12.5 Violation - apt artifacts found in /var/lib/apt/lists/" in context.res.stderr
     assert "/var/lib/apt/lists/partial" in context.res.stdout or "/var/lib/apt/lists/partial" in context.res.stderr
-
-    # Clean up after test
-    if hasattr(context, 'conf_bak'):
-        subprocess.run(["mv", context.conf_bak, "data/vm-types.conf"])
-        subprocess.run(["zsh", "-c", "bin/vde-matrix-rebuild.zsh --quiet"])
-    if os.path.exists("scripts/setup/chaos-init.zsh"):
-        os.remove("scripts/setup/chaos-init.zsh")

--- a/tests/features/steps/error_handling_steps.py
+++ b/tests/features/steps/error_handling_steps.py
@@ -33,7 +33,6 @@ def _register_container_cleanup(context, cmd):
                 capture_output=True
             )
             # Clear any stale VM lock left by a SIGKILL'd vde process
-            import shutil
             lock_dir = VDE_ROOT / ".locks" / "vms" / f"{a}.lock"
             shutil.rmtree(str(lock_dir), ignore_errors=True)
         context.add_cleanup(_cleanup)

--- a/tests/features/steps/error_handling_steps.py
+++ b/tests/features/steps/error_handling_steps.py
@@ -18,12 +18,34 @@ def step_background_lock(context, vm_alias):
     context.background_pid = pid
     context.add_cleanup(lambda: shutil.rmtree(str(lock_dir), ignore_errors=True))
 
+def _register_container_cleanup(context, cmd):
+    """Register cleanup for any container started by a 'start <alias>' command.
+    The signal rig may leave a container running if it was created before the
+    signal killed the vde process — ensure stop+rm runs regardless of outcome.
+    Uses docker directly to bypass VDE's lock system, which can be left in a
+    stale state when the vde process is killed with SIGKILL."""
+    parts = cmd.split()
+    if len(parts) >= 2 and parts[0] == "start":
+        alias = parts[1]
+        def _cleanup(a=alias):
+            subprocess.run(
+                ["docker", "rm", "-f", f"vde-{a}"],
+                capture_output=True
+            )
+            # Clear any stale VM lock left by a SIGKILL'd vde process
+            import shutil
+            lock_dir = VDE_ROOT / ".locks" / "vms" / f"{a}.lock"
+            shutil.rmtree(str(lock_dir), ignore_errors=True)
+        context.add_cleanup(_cleanup)
+
 @when('I simulate a user interruption (SIGINT) during "{command_str}"')
 def step_physical_sigint(context, command_str):
     # Strip 'bin/vde ' from the start if present
     cmd = command_str.replace("bin/vde ", "")
     rig_path = VDE_ROOT / "plans" / "scripts" / "signal-strike.zsh"
-    
+
+    _register_container_cleanup(context, cmd)
+
     # Execute the physical injection rig
     res = subprocess.run(
         [str(rig_path), "SIGINT", cmd],
@@ -31,7 +53,7 @@ def step_physical_sigint(context, command_str):
         text=True,
         cwd=VDE_ROOT
     )
-    
+
     context.command_output = res.stdout + res.stderr
     context.command_exit_code = res.returncode
 
@@ -39,14 +61,16 @@ def step_physical_sigint(context, command_str):
 def step_physical_sigkill(context, command_str):
     cmd = command_str.replace("bin/vde ", "")
     rig_path = VDE_ROOT / "plans" / "scripts" / "signal-strike.zsh"
-    
+
+    _register_container_cleanup(context, cmd)
+
     res = subprocess.run(
         [str(rig_path), "SIGKILL", cmd],
         capture_output=True,
         text=True,
         cwd=VDE_ROOT
     )
-    
+
     context.command_output = res.stdout + res.stderr
     context.command_exit_code = res.returncode
 


### PR DESCRIPTION
### Fracture Analysis
Several BDD features (dns-discovery, phase31-dns-discovery, jupyterlab-spoke) were starting Docker containers but failing to clean them up after the feature or in case of test failure/interruption. This led to Rule K (3-VM concurrent limit) exhaustion, causing subsequent tests to fail with port contention or lock errors.

### The Reforging
1. **tests/features/environment.py**: Added before/after feature hooks to force-remove containers for tags @dns and @jupyterlab. This ensures a clean state before features start and prevents leaks after they finish.
2. **tests/features/steps/error_handling_steps.py**: Hardened signal tests to register container and lock cleanup before simulating SIGINT/SIGKILL. This ensures that even if the vde process is killed forcefully, its side effects (containers/locks) are purged.
3. **tests/features/steps/chaos_steps.py**: Improved cleanup logic using `context.add_cleanup` for temporary setup scripts and registry restoration, ensuring no ghost files or corrupted configurations persist after chaos scenarios.

### The Beskar Set
- tests/features/environment.py
- tests/features/steps/error_handling_steps.py
- tests/features/steps/chaos_steps.py

Closes #352

## Summary by Sourcery

Improve BDD test reliability by ensuring Docker containers, locks, and temporary artifacts are consistently cleaned up before and after relevant features and chaos/error-handling scenarios.

Enhancements:
- Ensure DNS and JupyterLab BDD features always start from a clean Docker state and do not leave spokes running after completion.
- Register cleanup of containers and VM locks created by signal-handling tests to prevent stale resources after SIGINT/SIGKILL scenarios.
- Add automatic cleanup of temporary chaos-init scripts and restoration of VM configuration after chaos feature runs.

Tests:
- Harden BDD environment and step definitions to avoid leaking Docker containers, filesystem artifacts, and locks that could exhaust shared test resources.