### PR TITLE
chore(release): synchronize 1.5.2 gospel to main

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,24 +1,7 @@
-# VDE Beskar Record: 1.5.1 (The Sovereign Evolution)
-<!-- @shared-law (Forge Component) -->
+# VDE Memory: Standing Watch
+# @shared-law (Forge Component)
 
-## SOVEREIGN STATE
-- **Baseline**: 1.5.1 (Certified 2026-04-27)
-- **Status**: 100% GREEN (PEAK INTEGRITY)
-- **Heartbeat**: Certified via Mandate L; automated via pre-push and CI.
-
-## CORE MEMORIES (1.5.1)
-- **Sovereign Baseline Hardening (2026-04-28)**: Enforced Alphabetical Porting Law (32 VMs). Upgraded Entrypoint to v2.5.4 (PATH preservation + Socket hardening). Purified MCP to Context7 ONLY. Heartbeat 100% Certified.
-- **Sovereign Startup (2026-04-28)**: Remediated SSH Spine failure and certified Heartbeat (100% PASS). Disabled all MCP servers except Context7 as per Clan Leader command.
-- **Sovereign Scope Hardening**: Anchored the `vde` CLI to the absolute project root via `bin/vde` and `lib/vde-constants`. The Armor is now location-blind; strikes can be executed from any host directory while maintaining strict internal scoping.
-- **Sovereign Initialization (1.5.1)**: Completed session ignition with a 100% success rate across all rituals (UAP Audit, Spine Check, Proof of Life).
-- **Branch Alignment Strike**: Synchronized the absolute SHA (`fe6ab8f6`) across `develop`, `main`, and `stable`. Certified the alignment by moving the `1.5.1` tag and GitHub Release.
-- **Documentation Unification**: Successfully re-forged the entire documentation tree (30+ files) to align with the 1.5.1 Sovereign Baseline, Armor/Forge split, and `devuser` identity.
-- **Identity Hardening**: Certified the distinction between `devuser` (Spoke account) and `vde_student` (SSH identity key).
-- **Universal Onboarding**: Established `bin/vde path-of-the-foundling` as the primary Induction and Certification path.
-- **Cross-Platform Purity**: Verified WSL2, macOS, and Linux prerequisite paths for a universal Zsh-native environment.
-
-## THE NEXT STRIKE (CRITICAL)
-- **Absolute Objective**: Maintain the 100% pass rate and documentation parity as the system evolves.
-- **Synchronization**: Ensure all local changes are synchronized and tagged on the remote record.
-
-**This is the Way.**
+## SOVEREIGN BASELINE: 1.5.2
+- VDE 1.5.2 is the unique, global Sovereign Baseline.
+- All prior versions are of historical archival value only.
+- Heartbeat Certified.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,7 @@
-## Project Status: 1.5.1 (Sovereign Baseline) - Released
+## Project Status: 1.5.2 (Sovereign Baseline) - Released
+<!-- @shared-law (Forge Component) -->
 
-- **Version**: 1.5.1
+- **Version**: 1.5.2
 - **Status**: Stable / Released
 - **Summary**: This version hardens the Transversal Bridge (SSH), eliminates initialization fractures, and introduces a resilient dynamic identity injection system. The Forge is now fully capable of clean-slate bootstrapping as per the New Foundling ritual.
 - **Key Remediations**:
@@ -8,4 +9,4 @@
   - VDE-SPINE-01 (Isolated Agent Discovery)
   - VDE-AGENT-DISCOVERY (Global Agent Discovery)
   - VDE-BASE-CHOWN (Base Image Build Permissions)
-- **Current SHA**: a19c968676c046534dcd8c80561526219991df85
+- **Current SHA**: adc83d3d5b5c432f3da5c97fbcbfd74c36af540f

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 # VDE Release Archive
+<!-- @shared-law (Forge Component) -->
 
 This file tracks the evolution of the Virtual Development Environment. For detailed technical changes and empirical certifications, refer to the individual release records in `docs/releases/`.
 

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -57,6 +57,6 @@ The "Unyielding Tetrad" (Zsh, Git, Docker, SSH) forms a foundation that is remar
 *   **For Students:** Implement a **"Path of the Foundling"** onboarding script that introduces the rituals one by one.
 *   **For New Hires:** Maintain the **Rule Spine** without compromise. The friction they feel is simply the feeling of quality being forged.
 
-**THE VERDICT: 1.5.1 IS GREEN. THE FORGE IS STEADY.**
+**THE VERDICT: 1.5.2 IS GREEN. THE FORGE IS STEADY.**
 
 This is the Way.

--- a/VDE_ANALYSIS.md
+++ b/VDE_ANALYSIS.md
@@ -32,6 +32,6 @@ The VDE is a high-integrity orchestration layer that abstracts containerized env
 
 ### 5. Final Engineering Verdict
 
-**The VDE 1.5.1 Baseline is a robust, production-ready development framework.** It is uniquely positioned to bridge the gap between academic learning and professional engineering. By enforcing a "Sovereign" mindset—where the environment is treated with the same rigor as the application code—you are not just providing a workspace; you are establishing a culture of engineering excellence.
+**The VDE 1.5.2 Baseline is a robust, production-ready development framework.** It is uniquely positioned to bridge the gap between academic learning and professional engineering. By enforcing a "Sovereign" mindset—where the environment is treated with the same rigor as the application code—you are not just providing a workspace; you are establishing a culture of engineering excellence.
 
 **Current Status: SYSTEM GREEN. DEPLOYMENT AUTHORIZED.**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE
 <!-- @shared-law (Sovereign Law) -->
-# ARCHITECTURE 1.5.1 (The Sovereign Baseline)
+# ARCHITECTURE 1.5.2 (The Sovereign Baseline)
 
 ## 1. Philosophical Pillars (The Way)
 
@@ -9,7 +9,7 @@
     2. **Project 2: The Forge (`@forge`)**: The universal Development AI-Governance system. It manages the GitHub lifecycle, enforces mandates, and audits technical integrity.
 - **The Symbiotic Covenant**: The Forge shapes the Armor. Every change to the Forge must be justified by how it improves the Armor product for Foundlings (Students).
 - **The Creed-frame**: The narrative fuel established in `data/vde_core/**` must guide all thematic world-building.
-- **The Gospel**: The Sovereign Artifact Set is the absolute authority. 1.5.1 is the unique Sovereign Baseline.
+- **The Gospel**: The Sovereign Artifact Set is the absolute authority. 1.5.2 is the unique Sovereign Baseline.
 - **The Spine**: The system is built upon the **Unyielding Tetrad**: **Zsh, Git, Docker, and SSH**.
 
 ## 2. Structural Design (The Armor)
@@ -60,7 +60,7 @@ VDE enforces a strict branch-based release lifecycle to maintain the purity of t
 5.  **X.X.X Releases**: Step and milestone releases are applied against `main` only. `develop` remains for development only.
 
 ---
-Version: 1.5.1
+Version: 1.5.2
 Status: SOVEREIGN BASELINE CERTIFIED
 Identity: The Covert
 ---

--- a/docs/TECHNICAL_DEEP_DIVE.md
+++ b/docs/TECHNICAL_DEEP_DIVE.md
@@ -150,7 +150,7 @@ VDE implements a high-fidelity internal network resolution system to facilitate 
 - **Handshake Verification**: The `vde dns-check` command provides empirical proof of cross-Spoke connectivity, ensuring the Transversal Bridge is active.
 
 ---
-**Version**: 1.5.1
+**Version**: 1.5.2
 **Status**: SOVEREIGN BASELINE CERTIFIED
-**Reference**: ARCHITECTURE 1.5.1
+**Reference**: ARCHITECTURE 1.5.2
 ---

--- a/docs/VDE-SPEC.md
+++ b/docs/VDE-SPEC.md
@@ -4,7 +4,7 @@
 
 **Date**: 2026-05-01
 **Status**: SOVEREIGN BASELINE CERTIFIED
-**Reference**: ARCHITECTURE 1.5.1
+**Reference**: ARCHITECTURE 1.5.2
 **Identity**: The Covert
 
 ## 1. Absolute Mandates (The Rule Spine & The Gospel)
@@ -21,7 +21,7 @@
     4. **Pillar IV: SSH** (The Transversal Bridge) - Requires the `vde_student` identity to be active in the Hub's agent.
 - **The Proof of Life Contract (Mandate L)**: The lifecycle defined in `plans/system-spine-contract.md` is the project's **Heartbeat**. It mandates that ALL Spokes must reliably execute: `init`, `create`, `rebuild`, `start`, `enter`, `stop`, `remove`, `add`, and `uninstall`. Failure of any state is a Protocol Blockade.
 - **The Creed-frame**: The narrative fuel established in `data/vde_core/**` must guide all thematic world-building. No Spoke shall be ignited and no structure stabilized that does not align with the mythos.
-- **The Gospel Authority**: The Sovereign Artifact Set (specified in Section 3) is the **Gospel of the Forge**. These documents are the **limiting, or expanding, decision makers** on the **WHAT** and the **HOW** of all creation and refactoring. **1.5.1 is now the unique Sovereign Baseline. All prior versions and releases are of historical archival value only.**
+- **The Gospel Authority**: The Sovereign Artifact Set (specified in Section 3) is the **Gospel of the Forge**. These documents are the **limiting, or expanding, decision makers** on the **WHAT** and the **HOW** of all creation and refactoring. **1.5.2 is now the unique Sovereign Baseline. All prior versions and releases are of historical archival value only.**
 - **The Use-Case Creed**: The Forge exists solely to serve the Foundlings (Students) and Reinforcements (New Hires). This is **Creed**. All technical work MUST be centrally driven by its direct improvement to the onboarding and educational experience of these two cohorts.
 - **The Mandate of Architectural Tagging**: ALL artifacts (code, tests, docs, config) MUST be tagged according to their Project alignment (@armor, @forge, or @shared-law) to maintain clear ownership and visibility.
     - **The Positioning Law**: Tags MUST be placed on **line 2 or 3** of every file. Line 1 is reserved for shebangs or file-specific headers.
@@ -104,5 +104,5 @@ The Forge is currently advancing through Phase 29:
 ---
 Version: 1.5.2
 **Status**: HARDENED
-**Reference**: RESOL’NARE 1.5.1
+**Reference**: RESOL’NARE 1.5.2
 ---

--- a/session_handover.md
+++ b/session_handover.md
@@ -1,43 +1,19 @@
-# VDE Session Handover: 2026-04-30
+# VDE Session Handover: 2026-05-01
 # @shared-law (Forge Component)
 
 ## SOVEREIGN STATE
-- **Baseline**: 1.5.1 (Sovereign Evolution)
-- **Branch**: `develop` @ `5459c618`
+- **Baseline**: 1.5.2 (Sovereign Baseline)
+- **Branch**: `develop` @ `adc83d3d`
 - **Status**: 100% GREEN (PEAK INTEGRITY)
-- **Heartbeat**: 72/72 BDD Steps PASS (Proof of Life certified on push)
-- **MCP Configuration**: Context7 ONLY (Purified)
-- **Active Plans**: NONE — plan space fully cleared
+- **Heartbeat**: Certified via PoL 1.5.2
 
-## COMPLETED STRIKES (This Session)
-
-### Strike 1 — Workspace Hygiene / Absolute Path Purification (PR #340, Issue #339)
-
-**Root cause**: `plans/scripts/test_fifo.zsh` was committed in `1d729ef2` before the path-purification-strike (PR #337) and was missed. The test step in `concurrency_queue_steps.py` was also regenerating the file with absolute paths on every run.
-
-**Changes merged**:
-- `tests/features/steps/concurrency_queue_steps.py` — converted `write_text(f"...")` Python f-string to plain `write_text("...")` using ZSH `${VDE_ROOT_DIR:-${0:A:h:h:h}}` self-location. Eliminates absolute-path regeneration at test runtime.
-- `bin/vde-security-audit.zsh` — added `--exclude-dir=.claude` to both grep scans. Prevents false positives from Claude Code's gitignored `.claude/settings.local.json` permission config.
-- `.gitignore` — added `plans/scripts/fifo_test.log` and `/pretty.output`.
-- `docs/VDE-SPEC.md` — removed 8 duplicate `(The Sovereign Evolution)` suffixes from subtitle line (tool corruption from a previous session).
-
-### Strike 2 — FIFO Concurrency Race Fix + Sourcery Remediations (PR #343, Issue #341)
-
-**Root cause**: `arrival_interval = 0.05s` (50ms) was less than observed ZSH startup + 3-source time (≈102ms avg). Workers were not arriving in deterministic order before the first lock acquisition, causing non-deterministic FIFO test results.
-
-**Changes merged**:
-- `tests/features/steps/concurrency_queue_steps.py` — `arrival_interval` raised to 0.200s; extracted as `ARRIVAL_INTERVAL_SECONDS` module constant with rationale comment; `interval` step parameter now wired through; assertion fixed to compare acquisitions vs arrivals.
-- `tests/features/core-infrastructure/concurrency-queue.feature` — step updated to `at 0.200s intervals`.
-- `bin/vde-security-audit.zsh` — `_grep_excludes` declared `typeset -a`; `grep | wc -l` boolean replaced with `grep -rq` single pass; duplicate exclude-dir lists extracted to ZSH arrays.
-
-**Key observations**:
-- Race condition was empirically confirmed: 50ms < 102ms ZSH startup floor. 200ms gives 2× margin.
-- `plans/scripts/test_fifo.zsh` is gitignored by `test_*.zsh` — the generator in `concurrency_queue_steps.py` is authoritative.
-- SSH Pillar IV required `~/.ssh/vde/agent_env` update at session start (stale PID from previous session). This is an expected per-session maintenance step.
+## STRIKE SUMMARY: VDE 1.5.2 Escalation
+- **Container Leak Remediation**: Hardened BDD suite (`environment.py`, `steps/`) to ensure deterministic Spoke cleanup.
+- **Version Escalation**: Bumped version to 1.5.2 across 21 core artifacts using `vde-sync-version`.
+- **Production Merge**: Synchronized `develop` into `main` and published GitHub Release 1.5.2.
 
 ## NEXT STEPS
-- No active plans. Forge is clean.
-- Phase 33 Preparation: Deep AI-Product Symbiosis (when ready).
-- Any new work follows the STRIKE PROTOCOL: Signet → Branch → Implement → Chronicle → PRE-MERGE HALT → Merge.
+- No active missions. Forge is clean.
+- All future analysis must be measured against the 1.5.2 Baseline.
 
 **This is the Way.**


### PR DESCRIPTION
## Fracture Analysis
The previous 1.5.2 release contained Gospel drift (outdated references to 1.5.1). This has been remediated on develop.

## The Reforging
Synchronizing the clean 1.5.2 state from develop to main.

## The Beskar Set
- All Gospel artifacts (synchronized to 1.5.2)

Closes #360

## Summary by Sourcery

Synchronize documentation and status records with the VDE 1.5.2 Sovereign Baseline and recorded release state.

Documentation:
- Update all Gospel and architecture documents to reference 1.5.2 as the unique Sovereign Baseline and correct version metadata.
- Refresh session handover, project status, and analysis narratives to describe the 1.5.2 release, including container cleanup and version escalation details.