### PR TITLE
fix(docs): remediate peripheral gospel drift for 1.5.2

### DIFF
--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -1,7 +1,7 @@
 # **The Way of the VDE: 1.5.2 (The Sovereign Baseline)**
 <!-- @forge (Governance Sentinel) -->
 
-This is the Way of the VDE. Certified as the **Sovereign Baseline** as of version 1.5.1. All core mandates are enforced, and the testing suite maintains a 100% pass rate with empirical proof.
+This is the Way of the VDE. Certified as the **Sovereign Baseline** as of version 1.5.2. All core mandates are enforced, and the testing suite maintains a 100% pass rate with empirical proof.
 
 MANDATE: In VDE workspace, follow instructions in AGENTS.md.
 
@@ -180,7 +180,7 @@ Failure of any ritual constitutes a **Protocol Blockade**.
     * **The Chronicler’s Law**: Commit messages MUST follow the format defined in `COMMIT_MESSAGE_FORMAT.md`.
     * Failure to utilize these templates constitutes a procedural fracture and requires immediate remediation.
 
-## **THE SOVEREIGN INSTRUCTION SET 1.5.1**
+## **THE SOVEREIGN INSTRUCTION SET 1.5.2**
 
 *"The core beating heart forged in every piece of Beskar made by this Forge."*
 
@@ -495,8 +495,8 @@ Every commit MUST be labeled with ALL functional effect tags present across ALL 
 | (file path) | @forge | (Functional description) |
 | (file path) | @shared-law | (Functional description) |
 
-## SESSION STATUS (2026-04-28)
+## SESSION STATUS (2026-05-03)
 - **Status**: 100% Green (Heartbeat Certified)
-- **SHA**: fe6ab8f6 (Aligned: develop, main, stable)
-- **Tag**: 1.5.1 (Moved to certified SHA)
-- **Strike**: Sovereign Scope Hardening complete.
+- **SHA**: d458730e (main/stable — 1.5.2 tag) / b21b9cc2 (develop, clean)
+- **Tag**: 1.5.2 (Sovereign Baseline — CERTIFIED)
+- **Strike**: Peripheral Gospel Drift Remediation complete.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,4 +9,4 @@
   - VDE-SPINE-01 (Isolated Agent Discovery)
   - VDE-AGENT-DISCOVERY (Global Agent Discovery)
   - VDE-BASE-CHOWN (Base Image Build Permissions)
-- **Current SHA**: adc83d3d5b5c432f3da5c97fbcbfd74c36af540f
+- **Current SHA**: d458730e28133012ba1647e2050189ffbdf39f38

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![CI Status](https://github.com/dderyldowney/vde-system/actions/workflows/vde-ci.yml/badge.svg)
 
-A sovereign, template-based ecosystem of Dockerized Spokes. Forged for the warrior who demands absolute isolation, consistent hydration, and governed development. 1.5.1 is the **Sovereign Baseline**, certified through the Proof of Life contract.
+A sovereign, template-based ecosystem of Dockerized Spokes. Forged for the warrior who demands absolute isolation, consistent hydration, and governed development. 1.5.2 is the **Sovereign Baseline**, certified through the Proof of Life contract.
 
 **🛡️ The Sovereign Record:** The default branch for this Forge is `develop` (**The Anvil**). Stable, certified releases reside on `main` (**Production**).
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2,7 +2,7 @@
 <!-- @armor (Student Documentation) -->
 <p align="center"><img src="docs/imgs/vde-system-logo.png" alt="Virtualized Development Environment System Logo"></p>
 
-# VDE User Guide: The Path of the Foundling (1.5.1)
+# VDE User Guide: The Path of the Foundling (1.5.2)
 
 Welcome to the **Virtualized Development Environment (VDE)**. This guide is your map to forging a sovereign development ecosystem.
 
@@ -32,7 +32,7 @@ bin/vde path-of-the-foundling
 Inside any Spoke, you operate as the `devuser`. Your code lives at `$HOME/workspace/`. This directory is **persistently synced** to `projects/<alias>` on your host machine. Save your work here to ensure it survives Spoke rebuilds.
 
 ### Clusters and Discovery
-VDE 1.5.1 supports multi-Spoke tech stacks:
+VDE 1.5.2 supports multi-Spoke tech stacks:
 ```vde start python postgres redis```
 Spokes discover each other automatically by name. Python can reach Postgres at `vde-postgres` and Redis at `vde-redis`.
 

--- a/VDE_INSTALL.md
+++ b/VDE_INSTALL.md
@@ -1,8 +1,8 @@
 # VDE INSTALLATION
 <!-- @armor (Installation Ritual) -->
-# The Installation Ritual (1.5.1)
+# The Installation Ritual (1.5.2)
 
-Welcome, Foundling. To ignite your own Forge and walk the path of the VDE, you must first secure the **Unyielding Tetrad** on your host machine. This process establishes and certifies your **Sovereign Baseline 1.5.1**.
+Welcome, Foundling. To ignite your own Forge and walk the path of the VDE, you must first secure the **Unyielding Tetrad** on your host machine. This process establishes and certifies your **Sovereign Baseline 1.5.2**.
 
 ---
 

--- a/VDE_PROTOCOL.md
+++ b/VDE_PROTOCOL.md
@@ -1,6 +1,6 @@
 # VDE PROTOCOL
 <!-- @shared-law (Operational Protocol) -->
-# The Protocol of the Forge (1.5.1)
+# The Protocol of the Forge (1.5.2)
 
 This protocol defines the immutable laws for interacting with the **Sovereign Baseline**. Deviation from these rituals is a breach of the Creed and may trigger a Protocol Blockade.
 

--- a/docs/releases/1.5.2.md
+++ b/docs/releases/1.5.2.md
@@ -2,12 +2,18 @@
 <!-- @shared-law (Sovereign Baseline Record) -->
 
 **Release Date:** 2026-05-02
-**Status:** 🔴 PENDING
-**Git SHA:** `d3ecf113feb5d3ddef025cfc5a54ae842196a4b9`
+**Status:** 🟢 RELEASED
+**Git SHA:** `d458730e28133012ba1647e2050189ffbdf39f38`
 
 ## 🛡️ Core Highlights
 
-Highlights pending documentation in MEMORY.md
+Version 1.5.2 delivers critical hardening of the Transversal Bridge (SSH infrastructure), eliminates initialization fractures, and introduces a resilient dynamic identity injection system. The Forge is now fully capable of clean-slate bootstrapping as per the New Foundling ritual.
+
+**Key Remediations:**
+- **VDE-CASCADE-01**: Eliminated recursive smelt loop causing Forge initialization failures
+- **VDE-SPINE-01**: Resolved isolated agent discovery failures during Spoke ignition
+- **VDE-AGENT-DISCOVERY**: Implemented global SSH agent discovery for robust identity loading
+- **VDE-BASE-CHOWN**: Fixed base image build permissions fracture
 
 ## 🏗️ The System Spine
 
@@ -22,5 +28,5 @@ Certified verification of the four pillars:
 - **Anvil Branch**: `develop` (Active Forge)
 
 ---
-**Certification**: 0 BDD Steps, 0 Scenarios, 0 Unit Tests, 100% PASS.
+**Certification**: 72 BDD Steps, 6 Scenarios, 0 Unit Tests, 100% PASS.
 **Dual Audit Loop**: 🟢 CODE AUDIT PASSED | 🟢 SECURITY AUDIT PASSED

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,7 +1,7 @@
 # Requirements
 <!-- @shared-law (Sovereign Law) -->
 
-This document outlines the system requirements for the **Sovereign Baseline (1.5.1)**.
+This document outlines the system requirements for the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/session_handover.md
+++ b/session_handover.md
@@ -1,9 +1,9 @@
-# VDE Session Handover: 2026-05-02
+# VDE Session Handover: 2026-05-03
 # @shared-law (Forge Component)
 
 ## SOVEREIGN STATE
 - **Baseline**: 1.5.2 (Sovereign Baseline)
-- **Branch**: `develop` @ `79bb7c68`
+- **Branch**: `develop` @ `b21b9cc2`
 - **Status**: 100% GREEN (PEAK INTEGRITY)
 - **Heartbeat**: Certified via PoL 1.5.2
 
@@ -13,9 +13,10 @@
 - **Production Sync**: Merged `develop` into `main` and updated the GitHub Release.
 - **Stable Mirror**: Mirrored `main` to `stable`.
 - **Archival**: Cleared `plans/` space for a fresh start.
+- **feat/expose-check-tetrad (PR #363)**: Exposed check-tetrad command in vde CLI (@armor).
 
 ## NEXT STEPS
-- **Phase 33**: Ready for next mission objectives.
+- Peripheral gospel drift remediation (Strike #364) in progress.
 - Forge is clean and standing watch.
 
 **This is the Way.**

--- a/tests/features/advanced-orchestration/dns-discovery.feature
+++ b/tests/features/advanced-orchestration/dns-discovery.feature
@@ -8,7 +8,7 @@ Feature: Spoke-to-Spoke DNS Discovery
 
   Background: Core Services are Active
     Given the VDE system is healthy
-    And the Hub is synchronized to version 1.5.1
+    And the Hub is synchronized to version 1.5.2
     And "python" is running
     And "postgres" is running
 

--- a/tests/features/advanced-orchestration/phase31-dns-discovery.feature
+++ b/tests/features/advanced-orchestration/phase31-dns-discovery.feature
@@ -8,7 +8,7 @@ Feature: Phase 31 - Spoke-to-Spoke DNS & Sovereign Bridge
 
   Background: Core Services are Active
     Given the VDE system is healthy
-    And the Hub is synchronized to version 1.5.1
+    And the Hub is synchronized to version 1.5.2
     And "python" is running
     And "postgres" is running
 

--- a/tests/features/core-infrastructure/gateway-pillars.feature
+++ b/tests/features/core-infrastructure/gateway-pillars.feature
@@ -8,7 +8,7 @@ Feature: The Four Pillars Gateway
 
   Background: Hub Readiness
     Given the Hub is active
-    And the Hub is synchronized to version 1.5.1
+    And the Hub is synchronized to version 1.5.2
 
   @pillar-1 @docker
   Scenario: Pillar I - The World-Forge (Docker Readiness)

--- a/tests/features/core-infrastructure/ssh-config-version.feature
+++ b/tests/features/core-infrastructure/ssh-config-version.feature
@@ -7,5 +7,5 @@ Feature: SSH Configuration Version Alignment
   So that the Forge remains synchronized
 
   Scenario: Verify SSH Configuration Version
-    Given the Hub is synchronized to version 1.5.1
-    Then the file "configs/ssh/config" should contain "Sovereign Baseline: 1.5.1"
+    Given the Hub is synchronized to version 1.5.2
+    Then the file "configs/ssh/config" should contain "Sovereign Baseline: 1.5.2"

--- a/tests/features/governance/phase32-auto-remediation.feature
+++ b/tests/features/governance/phase32-auto-remediation.feature
@@ -8,7 +8,7 @@ Feature: Phase 32 - Forge Intelligence & Auto-Remediation
 
   Background: The Forge is Initialized
     Given the VDE system is healthy
-    And the Hub is synchronized to version 1.5.1
+    And the Hub is synchronized to version 1.5.2
 
   Scenario: Empirical Proof: Registry Self-Healing (CONF -> JSON)
     Given I corrupt the Beskar Registry "data/vm-types.json" with invalid content
@@ -19,7 +19,7 @@ Feature: Phase 32 - Forge Intelligence & Auto-Remediation
   Scenario: Empirical Proof: Gospel Version Synchronization
     Given I intentionally drift the version in "RELEASE_NOTES.md" to "0.0.1"
     When I execute "bin/vde heal"
-    Then the file "RELEASE_NOTES.md" should contain the Sovereign Baseline version "1.5.1"
+    Then the file "RELEASE_NOTES.md" should contain the Sovereign Baseline version "1.5.2"
     And the Gospel Audit must report "synchronized"
 
   Scenario: Empirical Proof: Path Leak Remediation (Blockade Simulation)


### PR DESCRIPTION
## Fracture Analysis (What Was Wrong)

Strike #359 synchronized the nine Sovereign Artifacts to 1.5.2, but 14 peripheral files remained on 1.5.1. Gospel drift was present across:
- Student-facing documentation (USER_GUIDE, VDE_INSTALL, VDE_PROTOCOL, README, docs/requirements)
- BDD test feature files — hub version sync steps asserting 1.5.1 against a 1.5.2 spec (would fail on run)
- The governing instructions document (.gemini/instructions.md) — body text, instruction set header, and SESSION STATUS block
- docs/releases/1.5.2.md — status PENDING, stale SHA, zero certification counts, no content
- PROJECT_STATUS.md — SHA pointed to a pre-tag commit, not the actual 1.5.2 release commit

## The Reforging (What Was Fixed)

- **5 peripheral docs**: Updated Sovereign Baseline declarations from 1.5.1 → 1.5.2 in headers and body text
- **5 BDD test features**: Updated hub version sync step from 1.5.1 → 1.5.2; updated phase32 RELEASE_NOTES assertion to match current gospel
- **docs/releases/1.5.2.md**: Status RELEASED, SHA corrected to `d458730e`, real highlights written, cert counts updated to 72 steps / 6 scenarios
- **PROJECT_STATUS.md**: SHA updated to the actual 1.5.2 tag commit on main (`d458730e`)
- **.gemini/instructions.md**: 3 refs updated (body line 4, instruction set section header, SESSION STATUS block)
- **session_handover.md**: Date, develop SHA, PR #363 entry, and NEXT STEPS updated

All historical 1.5.1 references (docs/releases/1.5.1.md, bin/archive/, SHA-pinned epistemic mapping) were preserved per user constraint.

## The Beskar Set (Files Involved)

| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| `.gemini/instructions.md` | @forge | Governance Sentinel — version refs and SESSION STATUS |
| `PROJECT_STATUS.md` | @shared-law | Forge Component — release SHA corrected |
| `README.md` | @shared-law | Forge Component — Sovereign Baseline claim |
| `USER_GUIDE.md` | @armor | Student Documentation — version in title and body |
| `VDE_INSTALL.md` | @armor | Installation Ritual — version in header and body |
| `VDE_PROTOCOL.md` | @shared-law | Operational Protocol — version in header |
| `docs/requirements.md` | @shared-law | Sovereign Law — Sovereign Baseline declaration |
| `docs/releases/1.5.2.md` | @shared-law | Sovereign Baseline Record — finalized |
| `session_handover.md` | @shared-law | Forge Component — current session state |
| `tests/features/core-infrastructure/ssh-config-version.feature` | @forge | Version sync + SSH config assertion |
| `tests/features/core-infrastructure/gateway-pillars.feature` | @forge | Pillar gateway version sync |
| `tests/features/advanced-orchestration/dns-discovery.feature` | @forge | DNS discovery version sync |
| `tests/features/advanced-orchestration/phase31-dns-discovery.feature` | @forge | Phase 31 feature version sync |
| `tests/features/governance/phase32-auto-remediation.feature` | @forge | Phase 32 hub sync + RELEASE_NOTES assertion |

## Evidence

```
Pre-push Proof of Life (Mandate L):
1 feature passed, 0 failed, 0 skipped
6 scenarios passed, 0 failed, 0 skipped
72 steps passed, 0 failed, 0 skipped

Gospel Audit: [GOSPEL-SUCCESS] Sovereign Artifact Set is synchronized.
UAP Enforcer: [UAP-SUCCESS] All core mandates satisfied.
ssh-config-version + gateway-pillars targeted run: 2 features, 6 scenarios, 33 steps — all PASS
```

## Checklist of the Creed
- [x] Focused Strike (scope limited to Signet #364)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified (pre-push PoL 6/6)
- [x] Dual-Gate Review complete (enforcer + targeted BDD)
- [x] Documentation updated

Closes #364

## Summary by Sourcery

Align documentation, governance metadata, and BDD tests with the 1.5.2 Sovereign Baseline release and its actual tagged commit.

New Features:
- Document the core highlights and key remediations delivered in release 1.5.2, including SSH hardening and agent discovery improvements.

Bug Fixes:
- Correct outdated version references from 1.5.1 to 1.5.2 across user-facing docs, installation/protocol guides, and requirements documentation.
- Fix BDD feature files that asserted 1.5.1 behavior so they now validate against the 1.5.2 baseline and updated release notes.
- Update governance and status documents to reflect the certified 1.5.2 tag, current SHAs, and session status metadata.

Enhancements:
- Finalize the 1.5.2 release record with real highlights, accurate certification counts, and released status.
- Refresh the session handover log with the latest develop SHA, recent feature work, and current next steps.