### PR TITLE
fix(docs): remediate secondary docs/ gospel drift for 1.5.2

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -1,7 +1,7 @@
 # VDE Development Guide
 <!-- @forge (AI Governance) -->
 
-**Version:** 1.5.1 (The Sovereign Baseline)
+**Version:** 1.5.2 (The Sovereign Baseline)
 
 ## Code Style
 

--- a/docs/FOUNDLING_GUIDE.md
+++ b/docs/FOUNDLING_GUIDE.md
@@ -1,8 +1,8 @@
 # FOUNDLING GUIDE
 <!-- @shared-law (Sovereign Law) -->
-# Path of the Foundling: A Student's Guide to VDE (1.5.1)
+# Path of the Foundling: A Student's Guide to VDE (1.5.2)
 
-Welcome, Foundling. You have entered the Forge. This guide explains the "Rituals" (commands) and "Creed" (rules) you will follow to learn the ways of engineering within the **Sovereign Baseline (1.5.1)**.
+Welcome, Foundling. You have entered the Forge. This guide explains the "Rituals" (commands) and "Creed" (rules) you will follow to learn the ways of engineering within the **Sovereign Baseline (1.5.2)**.
 
 ---
 

--- a/docs/GITHUB_LIFECYCLE.md
+++ b/docs/GITHUB_LIFECYCLE.md
@@ -1,7 +1,7 @@
 # VDE GitHub Infrastructure Lifecycle
 <!-- @forge (AI Governance) -->
 
-This document defines the official procedures and lifecycle for interacting with the VDE Hub (GitHub). The VDE ecosystem consists of two distinct projects with separate responsibilities, governed by the **Sovereign Baseline (1.5.1)**.
+This document defines the official procedures and lifecycle for interacting with the VDE Hub (GitHub). The VDE ecosystem consists of two distinct projects with separate responsibilities, governed by the **Sovereign Baseline (1.5.2)**.
 
 ## 1. Project Separation
 

--- a/docs/Lifecycle_Of_A_Spoke.md
+++ b/docs/Lifecycle_Of_A_Spoke.md
@@ -1,6 +1,6 @@
 # LIFECYCLE OF A SPOKE
 <!-- @armor (Container Orchestration) -->
-**The Lifecycle of a Spoke in the VDE Sovereign Baseline (1.5.1)** is governed by the **Proof of Life Contract**, a non-negotiable functional sequence that ensures system integrity from initial hydration to final decommissioning.
+**The Lifecycle of a Spoke in the VDE Sovereign Baseline (1.5.2)** is governed by the **Proof of Life Contract**, a non-negotiable functional sequence that ensures system integrity from initial hydration to final decommissioning.
 
 ### **At a Glance: The Spoke Lifecycle**
 

--- a/docs/WHY_USE_VDE.md
+++ b/docs/WHY_USE_VDE.md
@@ -2,7 +2,7 @@
 <!-- @shared-law (Sovereign Law) -->
 <p align="center"><img src="imgs/vde-system-logo.png" alt="Virtualized Development Environment System Logo"></p>
 
-# Why VDE? Your Development Playground Awaits! (1.5.1) 🎉
+# Why VDE? Your Development Playground Awaits! (1.5.2) 🎉
 
 [← Back to README](../README.md)
 
@@ -100,7 +100,7 @@ VDE supports **24 programming languages/stacks** and **8 shared services** out o
 
 ## The "Magic" Part: Spokes Talking to Spokes ✨
 
-VDE 1.5.1 features automated **DNS Discovery**. If you're in your Python Spoke and need your database, just use its name:
+VDE 1.5.2 features automated **DNS Discovery**. If you're in your Python Spoke and need your database, just use its name:
 
 ```zsh
 # From inside your Python Spoke

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,7 +1,7 @@
 # Advanced Usage
 <!-- @shared-law (Sovereign Law) -->
 
-Advanced techniques and patterns for power users in the **Sovereign Baseline (1.5.1)**.
+Advanced techniques and patterns for power users in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/beskar-map.md
+++ b/docs/beskar-map.md
@@ -24,6 +24,6 @@ When a conflict arises or a decision must be weighed, the documents apply in the
 9.  **STDLIB.md**: The **Muscle**. The detailed reference for core library functions.
 
 ---
-**Current Sovereign Baseline: v1.5.1**
+**Current Sovereign Baseline: v1.5.2**
 **Identity: The Covert**
 **The Gospel is Nine. This is the Way.**

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,7 +1,7 @@
 # Best Practices
 <!-- @shared-law (Sovereign Law) -->
 
-Recommended practices for working with VDE effectively in the **Sovereign Baseline (1.5.1)**.
+Recommended practices for working with VDE effectively in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,7 +1,7 @@
 # Command Reference
 <!-- @shared-law (Sovereign Law) -->
 
-Complete reference for all VDE commands in the **Sovereign Baseline (1.5.1)**.
+Complete reference for all VDE commands in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/context/context-engineering-progress.md
+++ b/docs/context/context-engineering-progress.md
@@ -2,7 +2,7 @@
 <!-- @forge (Context Documentation) -->
 
 **Project**: VDE (Virtualized Development Environment)  
-**Version**: 1.5.1 (Sovereign Baseline)  
+**Version**: 1.5.2 (Sovereign Baseline)  
 **Repository**: https://github.com/dderyldowney/vde-system  
 **Default Branch**: develop (The Anvil)  
 **Root Directory**: `${VDE_ROOT_DIR}` (typically `~/VDE`)  
@@ -46,7 +46,7 @@ to understand our methodology and where we left off, then help me with [your spe
 3. **Lock-Queue Model**: FIFO sequencing for determinism
 4. **Mandalorian Creed Framework**: Narrative-driven development philosophy
 
-**Current Focus**: 1.5.1 release - Sovereign Baseline with hardened SSH bridge and clean-slate bootstrapping
+**Current Focus**: 1.5.2 (Sovereign Baseline) — CERTIFIED. Gospel drift remediation complete across all documentation layers. Next: retag 1.5.2 on main, update GitHub Release, mirror to stable. Branching strategy transitioning to develop → stable → main for future releases.
 
 **Team Size**: Solo developer with AI collaboration (agent governance framework)
 

--- a/docs/context/project-overview.md
+++ b/docs/context/project-overview.md
@@ -2,8 +2,8 @@
 <!-- @forge (Context Documentation) -->
 
 **Project**: Virtual Development Environment (VDE)  
-**Version**: 1.5.1 (The Sovereign Baseline)  
-**Last Updated**: 2026-04-30
+**Version**: 1.5.2 (The Sovereign Baseline)  
+**Last Updated**: 2026-05-03
 
 ---
 
@@ -57,11 +57,12 @@ VDE is a sovereign, template-based ecosystem of Dockerized Spokes designed for d
 ---
 
 ## Current Focus
-**Version 1.5.1 (The Sovereign Baseline)** — CERTIFIED CLEAN:
-- All 1.5.1 remediations complete and merged
-- Absolute path purification complete (PRs #337, #340)
-- FIFO concurrency race resolved — arrival stagger raised 50ms→200ms, empirically verified (PR #343)
+**Version 1.5.2 (The Sovereign Baseline)** — CERTIFIED:
+- Gospel drift remediation complete across all documentation layers (PRs #365, #367)
+- feat/expose-check-tetrad merged (PR #363) — check-tetrad command exposed in vde CLI (@armor)
 - Heartbeat: 72/72 BDD steps green, no known open issues
+- Next: Retag 1.5.2 on main, update GitHub Release SHA, mirror to stable
+- Branching strategy transitioning: future releases via develop → stable → main
 
 ---
 

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -1,7 +1,7 @@
 # Directory Structure
 <!-- @shared-law (Sovereign Law) -->
 
-The complete directory layout of the **Sovereign Baseline (1.5.1)** installation.
+The complete directory layout of the **Sovereign Baseline (1.5.2)** installation.
 
 [← Back to README](../README.md)
 

--- a/docs/extending-vde.md
+++ b/docs/extending-vde.md
@@ -1,6 +1,6 @@
 # EXTENDING-VDE
 <!-- @shared-law (Sovereign Law) -->
-# Extending VDE (1.5.1)
+# Extending VDE (1.5.2)
 
 VDE is designed to be easily extensible. You can add support for new programming languages or services by updating the **Beskar Registry** and creating hydration scripts.
 

--- a/docs/mcp-configuration.md
+++ b/docs/mcp-configuration.md
@@ -1,7 +1,7 @@
 # MCP Configuration Documentation
 <!-- @forge (AI Governance) -->
 
-## Overview (1.5.1)
+## Overview (1.5.2)
 
 This document describes the MCP (Model Context Protocol) server configuration for the VDE project. MCP servers extend the capabilities of the Gemini CLI by providing specialized tools for various tasks.
 

--- a/docs/predefined-vm-types.md
+++ b/docs/predefined-vm-types.md
@@ -1,7 +1,7 @@
 # Predefined VM Types
 <!-- @shared-law (Sovereign Law) -->
 
-All available programming languages and services in the **Sovereign Baseline (1.5.1)**.
+All available programming languages and services in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,6 @@
 # QUICK-START
 <!-- @shared-law (Sovereign Law) -->
-# Quick Start (Sovereign Baseline 1.5.1)
+# Quick Start (Sovereign Baseline 1.5.2)
 
 Get up and running with VDE in minutes.
 

--- a/docs/rebuild-guidelines.md
+++ b/docs/rebuild-guidelines.md
@@ -1,7 +1,7 @@
 # Rebuild Guidelines
 <!-- @shared-law (Sovereign Law) -->
 
-When and how to rebuild containers in the **Sovereign Baseline (1.5.1)**.
+When and how to rebuild containers in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/ssh-configuration.md
+++ b/docs/ssh-configuration.md
@@ -1,7 +1,7 @@
 # SSH Configuration & Agent Forwarding
 <!-- @shared-law (Sovereign Law) -->
 
-VDE provides **automatic SSH configuration** and **SSH agent forwarding** for seamless communication in the **Sovereign Baseline (1.5.1)**.
+VDE provides **automatic SSH configuration** and **SSH agent forwarding** for seamless communication in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,8 @@
 # TROUBLESHOOTING
 <!-- @shared-law (Sovereign Law) -->
-# Troubleshooting (1.5.1)
+# Troubleshooting (1.5.2)
 
-Common issues and solutions for VDE in the **Sovereign Baseline (1.5.1)**.
+Common issues and solutions for VDE in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 

--- a/docs/vm-docker-config.md
+++ b/docs/vm-docker-config.md
@@ -1,7 +1,7 @@
 # VDE VM Docker Configuration
 <!-- @shared-law (Sovereign Law) -->
 
-Centralized Docker configuration for VDE VMs in the **Sovereign Baseline (1.5.1)**.
+Centralized Docker configuration for VDE VMs in the **Sovereign Baseline (1.5.2)**.
 
 ## Overview
 

--- a/docs/vscode-remote-ssh.md
+++ b/docs/vscode-remote-ssh.md
@@ -1,7 +1,7 @@
 # VSCode Remote-SSH
 <!-- @shared-law (Sovereign Law) -->
 
-Using VSCode Remote-SSH with VDE in the **Sovereign Baseline (1.5.1)**.
+Using VSCode Remote-SSH with VDE in the **Sovereign Baseline (1.5.2)**.
 
 [← Back to README](../README.md)
 


### PR DESCRIPTION
## Fracture Analysis
18 live docs/ files still declared Sovereign Baseline 1.5.1 after Strike #364 (PR #365).

## The Reforging
Bulk-updated all 18 current-state documentation files from 1.5.1 → 1.5.2.

## Preserved (1.5.1-specific, untouched)
- docs/VDE_EPISTEMIC_MAPPING.md — SHA-pinned historical reference
- docs/DEVELOPMENT_GUIDE.md — "As of 1.5.1" historical achievement line only
- docs/context/workflows/deployment-workflow.md — illustrative versioning examples
- docs/releases/1.5.1.md — historical release record

## The Beskar Set
18 docs/ files — all @shared-law (Documentation).

## Evidence
Pre-push: GOSPEL-SUCCESS — Sovereign Artifact Set synchronized. USP clean.

Closes #366

## Summary by Sourcery

Documentation:
- Refresh user and operational documentation to reference Sovereign Baseline 1.5.2, keeping historical 1.5.1 records intact.