### PR TITLE
chore(forge): update session handover for 1.5.2 closeout

### DIFF
--- a/session_handover.md
+++ b/session_handover.md
@@ -2,21 +2,33 @@
 # @shared-law (Forge Component)
 
 ## SOVEREIGN STATE
-- **Baseline**: 1.5.2 (Sovereign Baseline)
-- **Branch**: `develop` @ `b21b9cc2`
+- **Baseline**: 1.5.2 (Sovereign Baseline) — FULLY CLOSED OUT
+- **develop**: `6d0005c5` (HEAD — post gospel-drift remediation)
+- **main**: `e2096965` (production — 1.5.2 tag, GitHub Release Latest)
+- **stable**: `e2096965` (mirrored from main)
 - **Status**: 100% GREEN (PEAK INTEGRITY)
-- **Heartbeat**: Certified via PoL 1.5.2
+- **Heartbeat**: 6/6 scenarios, 72/72 steps — 100% GREEN
+- **Gospel Audit**: GOSPEL-SUCCESS (all Sovereign Artifacts synchronized)
 
-## STRIKE SUMMARY: 1.5.2 Synchronization & Gospel Remediation
-- **Gospel Sync**: Remediated version drift across all 9 Sovereign Artifacts.
-- **Tag Synchronization**: Forced-updated `1.5.2` tag to point to the new merge SHA.
-- **Production Sync**: Merged `develop` into `main` and updated the GitHub Release.
-- **Stable Mirror**: Mirrored `main` to `stable`.
-- **Archival**: Cleared `plans/` space for a fresh start.
-- **feat/expose-check-tetrad (PR #363)**: Exposed check-tetrad command in vde CLI (@armor).
+## STRIKE SUMMARY: 1.5.2 Closeout
+- **PR #363** — feat(armor): expose check-tetrad command in vde CLI
+- **PR #365** — fix(docs): remediate peripheral gospel drift for 1.5.2 (14 files)
+- **PR #367** — fix(docs): remediate secondary docs gospel drift + docs/context/ (21 files)
+- **PR #369** — chore(release): merge develop → main for 1.5.2 Sovereign Baseline closeout
+- **Tag 1.5.2** — force-retagged to `e2096965` (new main SHA post-closeout merges)
+- **GitHub Release** — updated to `e2096965`, published as Latest
+- **stable** — mirrored from main @ `e2096965`
+
+## BRANCHING STRATEGY (POST-1.5.2)
+Future releases use the new three-tier flow:
+1. Feature work on `develop`
+2. Merge `develop` → `stable` (QA/integration gate — let it bake)
+3. Merge `stable` → `main` as official Release (never skip stable)
+4. Retag + GitHub Release always on `main`
 
 ## NEXT STEPS
-- Peripheral gospel drift remediation (Strike #364) in progress.
-- Forge is clean and standing watch.
+- Forge is clean and standing watch on `develop`.
+- No open issues or pending strikes.
+- Ready for Phase 33+ new mission objectives under the new branching strategy.
 
 **This is the Way.**


### PR DESCRIPTION
## Fracture Analysis

Session handover document was stale — still showed `b21b9cc2` as the develop SHA and had incomplete next steps listing the gospel drift PRs as "in progress." The 1.5.2 closeout ritual completed in this session required a final state update.

## The Reforging

Updated `session_handover.md` to reflect the fully closed-out 1.5.2 Sovereign Baseline:
- All branch SHAs accurate (develop: `6d0005c5`, main/stable: `e2096965`)
- All 4 strikes recorded (#363, #365, #367, #369)
- Tag retag, GitHub Release (Latest), and stable mirror documented
- New branching strategy (develop → stable → main) recorded for future sessions
- Cleared stale "in progress" references

## The Beskar Set

| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| `session_handover.md` | @forge | Session state artifact — Forge closeout record |

## Checklist of the Creed

- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed (UAP-SUCCESS)
- [x] Rule Spine green (Spine Check PASS)
- [x] Heartbeat certified (6/6 scenarios, 72/72 steps — 100% GREEN)
- [x] Gospel Audit — GOSPEL-SUCCESS
- [x] Documentation updated

Closes #370

## Summary by Sourcery

Update Forge session handover record to reflect the fully closed-out 1.5.2 Sovereign Baseline state and branching strategy.

Documentation:
- Refresh session_handover.md with current branch SHAs, strike list, heartbeat and gospel audit status, and tagging/release details.
- Document the post-1.5.2 three-tier branching strategy (develop → stable → main) and confirm there are no remaining open strikes or follow-up actions.