### PR TITLE
feat(forge): implement vde function-trace diagnostic command

### DIFF
--- a/bin/vde
+++ b/bin/vde
@@ -51,6 +51,18 @@ trap 'vde_error_map 130; exit 130' SIGINT SIGTERM
 ACTION=$1
 shift # past command
 
+# ── FUNCTION TRACE MODE ──────────────────────────────────────────────────
+# Re-parse the real sub-command now so target resolution works correctly.
+# Actual wrapper installation is deferred until after target resolution
+# so that infrastructure calls (vde_cluster_exists etc.) don't pollute the trace.
+_VDE_FT_PENDING=""
+if [[ "${ACTION}" == "function-trace" ]]; then
+    _VDE_FT_PENDING=1
+    ACTION="$1"
+    shift
+fi
+# ─────────────────────────────────────────────────────────────────────────
+
 # =========================================================================
 # UNIVERSAL TARGET RESOLUTION (Clusters & Aliases)
 # =========================================================================
@@ -99,6 +111,15 @@ if [[ ${#input_targets} -gt 0 ]]; then
     done
 fi
 
+# Install trace wrappers after target resolution so the trace starts clean at dispatch
+if [[ -n "${_VDE_FT_PENDING}" ]]; then
+    source "${VDE_ROOT_DIR}/lib/vde-function-trace"
+    vde_trace_install
+    export VDE_TRACE_MODE=1
+    _VDE_TRACE_RECORDS+=("DISPATCH|0|${ACTION}|${VDE_ROOT_DIR}/bin/vde||targets=(${targets[*]:-}) force=${force:-false}")
+    trap 'vde_trace_display' EXIT
+    unset _VDE_FT_PENDING
+fi
 
 case ${ACTION} in
     init)
@@ -400,6 +421,7 @@ Diagnostics & Discovery:
   ps              List all active VDE containers and their statuses.
   networks        List and manage VDE Docker networks.
   health          Execute the Sovereign Audit for the Hub and infrastructure.
+  function-trace  Trace the full function call chain for a command without executing it.
   stats <name>    Display real-time resource usage for Spokes.
   port <name>     Retrieve the specific SSH or service port for an alias.
   validate        Verify the integrity of Beskar Registry schemas.

--- a/lib/vde-function-trace
+++ b/lib/vde-function-trace
@@ -74,6 +74,9 @@ _vde_trace_record_exit() {
     (( _VDE_TRACE_CALL_DEPTH > 0 )) && (( _VDE_TRACE_CALL_DEPTH-- )) || true
 }
 
+# Executor shims: intercept side-effecting calls before they fire.
+# To add a new executor: define a shell function with the same name below,
+# record "EXEC|..." in _VDE_TRACE_RECORDS when VDE_TRACE_MODE is set, return 0.
 _vde_trace_shim_executors() {
     docker() {
         if [[ -n "${VDE_TRACE_MODE}" ]]; then

--- a/lib/vde-function-trace
+++ b/lib/vde-function-trace
@@ -1,0 +1,229 @@
+#!/usr/bin/env zsh
+# @forge (Function Trace: Support Diagnostic Tool)
+# Provides vde_trace_install() and vde_trace_display() for the function-trace command.
+# Invoked from bin/vde when ACTION=function-trace.
+
+typeset -ga _VDE_TRACE_RECORDS=()
+typeset -gi _VDE_TRACE_CALL_DEPTH=0
+
+# Install trace wrappers on all currently-loaded VDE functions.
+# Must be called after all lib files are sourced.
+vde_trace_install() {
+    zmodload zsh/parameter 2>/dev/null || {
+        print "ERROR: zsh/parameter module not available" >&2
+        return 1
+    }
+
+    # Resolve VDE_ROOT_DIR to absolute path so relative-sourced files match correctly
+    local _vt_root="${VDE_ROOT_DIR:a}"
+
+    local fname src_file abs_src
+    for fname in ${(k)functions_source}; do
+        src_file="${functions_source[$fname]}"
+        # Normalize relative paths to absolute using resolved root
+        if [[ "${src_file}" == /* ]]; then
+            abs_src="${src_file}"
+        else
+            abs_src="${_vt_root}/${src_file##./}"
+        fi
+        [[ "${abs_src}" == "${_vt_root}"/* ]] || continue
+        [[ "${fname}" =~ "^(_vde_trace|vde_trace)" ]] && continue
+        _vde_trace_wrap_function "${fname}" "${abs_src}"
+    done
+
+    _vde_trace_shim_executors
+}
+
+_vde_trace_wrap_function() {
+    local fname="$1"
+    local src_file="$2"
+    local safe="${fname//[^a-zA-Z0-9_]/_}"
+    local orig_name="_vde_trace_orig_${safe}"
+
+    local orig_body="${functions[$fname]}"
+    [[ -z "${orig_body}" ]] && return 0
+
+    eval "${orig_name}() {
+${orig_body}
+}"
+
+    eval "
+${fname}() {
+    if [[ -n \"\${VDE_TRACE_MODE}\" ]]; then
+        _vde_trace_record_entry '${fname}' '${src_file}' \"\$@\"
+        local _tr_rc=0
+        ${orig_name} \"\$@\" || _tr_rc=\$?
+        _vde_trace_record_exit
+        return \${_tr_rc}
+    fi
+    ${orig_name} \"\$@\"
+}
+"
+}
+
+_vde_trace_record_entry() {
+    local fname="$1" src_file="$2"
+    shift 2
+    local is_int=0
+    [[ "${fname}" == _* ]] && is_int=1
+    _VDE_TRACE_RECORDS+=("CALL|${_VDE_TRACE_CALL_DEPTH}|${fname}|${src_file}|${is_int}|$*")
+    (( ++_VDE_TRACE_CALL_DEPTH ))
+}
+
+_vde_trace_record_exit() {
+    (( _VDE_TRACE_CALL_DEPTH > 0 )) && (( _VDE_TRACE_CALL_DEPTH-- )) || true
+}
+
+_vde_trace_shim_executors() {
+    docker() {
+        if [[ -n "${VDE_TRACE_MODE}" ]]; then
+            case "$1" in
+                compose)
+                    # Scan all args for the compose verb (may follow flags like -f)
+                    local _vde_verb=""
+                    local _vde_arg
+                    for _vde_arg in "$@"; do
+                        case "${_vde_arg}" in
+                            up|build|down|run) _vde_verb="${_vde_arg}"; break ;;
+                        esac
+                    done
+                    case "${_vde_verb}" in
+                        up|build|down|run)
+                            _VDE_TRACE_RECORDS+=("EXEC|${_VDE_TRACE_CALL_DEPTH}|docker $*||")
+                            return 0
+                            ;;
+                    esac
+                    ;;
+                build)
+                    _VDE_TRACE_RECORDS+=("EXEC|${_VDE_TRACE_CALL_DEPTH}|docker $*||")
+                    return 0
+                    ;;
+                run)
+                    case "$2" in
+                        --rm|-i|-d|-it|--rm*)
+                            _VDE_TRACE_RECORDS+=("EXEC|${_VDE_TRACE_CALL_DEPTH}|docker $*||")
+                            return 0
+                            ;;
+                    esac
+                    ;;
+            esac
+            command docker "$@"
+            return $?
+        fi
+        command docker "$@"
+    }
+
+    ssh() {
+        if [[ -n "${VDE_TRACE_MODE}" ]]; then
+            if [[ "$1" != "-"* ]]; then
+                _VDE_TRACE_RECORDS+=("EXEC|${_VDE_TRACE_CALL_DEPTH}|ssh $*||")
+                return 0
+            fi
+            case "$1" in
+                -T|-N|-f)
+                    _VDE_TRACE_RECORDS+=("EXEC|${_VDE_TRACE_CALL_DEPTH}|ssh $*||")
+                    return 0
+                    ;;
+                *)
+                    command ssh "$@"
+                    return $?
+                    ;;
+            esac
+        fi
+        command ssh "$@"
+    }
+}
+
+# Format and display the collected call trace.
+# Called via trap EXIT from bin/vde.
+vde_trace_display() {
+    unset VDE_TRACE_MODE
+
+    local use_color=0
+    [[ -t 1 ]] && use_color=1
+
+    local bold="" dim="" cyan="" yellow="" reset=""
+    if [[ "${use_color}" == "1" ]]; then
+        bold="\033[1m"
+        dim="\033[2m"
+        cyan="\033[36m"
+        yellow="\033[33m"
+        reset="\033[0m"
+    fi
+
+    print ""
+    print "${bold}══════════════════════════════════════════════${reset}"
+    print "${bold}  VDE FUNCTION TRACE${reset}"
+    print "${bold}══════════════════════════════════════════════${reset}"
+    print ""
+
+    local _vt_root="${VDE_ROOT_DIR:a}"
+    local prev_lib="" prev_lib_depth=0 found_exec=0
+    local -a parts=()
+    local type="" depth="" fname="" src_file="" is_int="" params="" relative_src=""
+    local lib_rel_depth=0 indent_str="" i=0
+
+    for record in "${_VDE_TRACE_RECORDS[@]}"; do
+        parts=("${(s:|:)record}")
+        type="${parts[1]}"
+        depth="${parts[2]}"
+        fname="${parts[3]}"
+        src_file="${parts[4]}"
+        is_int="${parts[5]}"
+        params="${(j:|:)parts[6,-1]}"
+
+        relative_src="${${src_file:a}/${_vt_root}/\$VDE_ROOT_DIR}"
+
+        if [[ "${type}" == "EXEC" ]]; then
+            found_exec=1
+            print "${yellow}▶ [EXECUTOR] ${fname}${reset}"
+            print ""
+            break
+        fi
+
+        if [[ "${type}" == "DISPATCH" ]]; then
+            print "${bold}[dispatch: vde ${fname}]${reset}"
+            print "Params: ${params}"
+            print "File: ${relative_src}"
+            print ""
+            prev_lib="${src_file}"
+            prev_lib_depth=0
+            continue
+        fi
+
+        if [[ "${src_file}" != "${prev_lib}" ]]; then
+            [[ -n "${prev_lib}" ]] && print ""
+            prev_lib="${src_file}"
+            prev_lib_depth="${depth}"
+        fi
+
+        lib_rel_depth=$(( depth - prev_lib_depth ))
+        indent_str=""
+        for (( i=0; i<lib_rel_depth; i++ )); do
+            indent_str+="  "
+        done
+
+        if [[ "${is_int}" == "1" ]]; then
+            print "${indent_str}${dim}[internal] Function: ${fname}()${reset}"
+        else
+            print "${indent_str}${cyan}Function: ${fname}()${reset}"
+        fi
+
+        if [[ -n "${params}" ]]; then
+            print "${indent_str}Params: ${params}"
+        else
+            print "${indent_str}Params: (none)"
+        fi
+        print "${indent_str}File: ${relative_src}"
+        print ""
+    done
+
+    if [[ "${found_exec}" == "0" ]] && [[ ${#_VDE_TRACE_RECORDS[@]} -gt 0 ]]; then
+        print "${dim}(trace complete — no executor boundary reached)${reset}"
+    elif [[ ${#_VDE_TRACE_RECORDS[@]} -eq 0 ]]; then
+        print "${yellow}(no function calls recorded)${reset}"
+    fi
+
+    print "${bold}══════════════════════════════════════════════${reset}"
+    print ""
+}

--- a/tests/features/governance/function-trace.feature
+++ b/tests/features/governance/function-trace.feature
@@ -1,0 +1,46 @@
+# Function Trace Diagnostic Command
+# @forge (Forge Diagnostic Tooling)
+Feature: VDE Function Trace Diagnostic Command
+  As a VDE support technician
+  I need to trace the full function call chain for any vde command
+  So I can diagnose user issues without executing side effects
+
+  @forge
+  Scenario: Trace produces function entries for a known command
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "Function:"
+    And the output should contain "File: $VDE_ROOT_DIR"
+    And the return code should be 0
+
+  @forge
+  Scenario: Trace shows library boundary transitions
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "lib/vm-common"
+    And the output should contain "bin/vde"
+
+  @forge
+  Scenario: Trace captures argument values passed to traced functions
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "Params: vde-python"
+
+  @forge
+  Scenario: Trace stops at executor boundary without starting the container
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "[EXECUTOR]"
+    And the container "vde-python" should not be running
+
+  @forge
+  Scenario: Trace identifies the executor coordinator function before the boundary
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "vde_run()"
+
+  @forge
+  Scenario: Trace includes the dispatch entry point
+    Given the Hub is active
+    When I execute "bin/vde function-trace start python"
+    Then the output should contain "dispatch: vde start"


### PR DESCRIPTION
## Fracture Analysis
No existing tool allowed a support technician or developer to see the full ZSH function call chain for a given `vde` command without executing its side effects. Diagnosing user issues required either live debugging or guessing from source code.

## The Reforging
Implements `vde function-trace <cmd>` — a zero-overhead diagnostic that, when invoked, wraps all currently-loaded VDE functions at runtime via ZSH `eval`, intercepts `docker`/`ssh` executors, and displays the complete call chain with per-function params and source file.

**Key design decisions:**
- Uses ZSH's `zsh/parameter` module (`$functions_source`) for live function enumeration — real-time path, never cached
- Executor shim intercepts `docker compose/build/run` and `ssh` without executing them — no side effects
- `(( ++depth ))` (pre-increment) guards against `set -e` exit when depth is 0
- All loop-local variables hoisted outside outer loop to prevent ZSH typeset echo artifact
- Docker compose verb scanning walks all args (handles `-f file.yml` before the verb)
- Zero overhead on normal `vde` commands — `VDE_TRACE_MODE` is never set during normal usage

## The Beskar Set
| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| `bin/vde` | @armor | Adds function-trace intercept block and late-binding trace install |
| `lib/vde-function-trace` | @forge | Runtime function wrapping, executor shims, and trace display |
| `tests/features/governance/function-trace.feature` | @forge | 6 BDD scenarios covering the full diagnostic feature surface |

## Checklist of the Creed
- [x] Focused Strike (scope limited to Signet #372)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified (6/6 PoL, 72/72 steps)
- [x] Dual-Gate Review complete
- [x] Documentation updated (architectural tags on all files)

Closes #372

## Summary by Sourcery

Add a diagnostic function-trace mode to vde for inspecting function call chains without executing side effects.

New Features:
- Introduce `vde function-trace <cmd>` to display the full ZSH function call chain, parameters, and source files for a given vde command.

Tests:
- Add BDD feature scenarios validating function trace output, library boundary visibility, argument capture, executor boundary handling, and dispatch entry inclusion.