### PR TITLE
fix(armor): correct environment file resolution and Spoke detection

### DIFF
--- a/lib/vm-common
+++ b/lib/vm-common
@@ -577,7 +577,7 @@ get_vm_compose_file() {
 get_vm_env_file() {
     local raw_name
     raw_name=$(vde_normalize_name "${1}")
-    echo "env-files/vde-${raw_name}.env"
+    echo "env-files/${raw_name}.env"
 }
 
 # get_vm_image - Derives image name from Hub name
@@ -788,24 +788,12 @@ is_known_vm() {
 # Returns: 0 if created (compose and env files exist), 1 otherwise
 vm_is_created() {
     local vm_name="${1}"
-    local raw_name="${vm_name#vde-}"
-    local full_name="vde-${raw_name}"
-    local configs_dir="${VDE_CONFIGS_DIR:-${VDE_ROOT_DIR}/configs/docker}"
-    local env_dir="${VDE_ENV_DIR:-${VDE_ROOT_DIR}/env-files}"
-    
-    # 1. Check NEW category-specific path first
-    local category
-    category=$(get_vm_category "${vm_name}")
-    if [[ "${category}" != "unknown" ]]; then
-        if [[ -f "${configs_dir}/${category}/${raw_name}/docker-compose.yml" ]] && \
-           [[ -f "${env_dir}/${full_name}.env" ]]; then
-            return 0
-        fi
-    fi
+    local compose_file
+    compose_file=$(get_vm_compose_file "${vm_name}")
+    local env_file
+    env_file=$(get_vm_env_file "${vm_name}")
 
-    # 2. Fallback to OLD conventional path
-    if [[ -f "${configs_dir}/${raw_name}/docker-compose.yml" ]] && \
-       [[ -f "${env_dir}/${full_name}.env" ]]; then
+    if [[ -f "${VDE_ROOT_DIR}/${compose_file}" ]] && [[ -f "${VDE_ROOT_DIR}/${env_file}" ]]; then
         return 0
     fi
     return ${VDE_ERR_GENERAL}


### PR DESCRIPTION
### I. Context (The Why)
The `get_vm_env_file` function was incorrectly prefixing environment files with `vde-`, causing them to be missed. This fix ensures Spoke-specific `.env` files are loaded correctly and Spokes are accurately identified as "Created".

### II. Signet Link (The Unbreakable Link)
Closes #379

### III. The Trial of the Gauntlet (Test Evidence)
```
▶ [EXECUTOR] docker compose -f configs/docker/languages/rust/docker-compose.yml --env-file ./.env --env-file ./env-files/rust.env build --no-cache
```
```
6 scenarios passed, 0 failed, 0 skipped
72 steps passed, 0 failed, 0 skipped
Took 2min 4.695s
```

### IV. Files Changed (The Beskar Plates)
- `lib/vm-common`: Corrected `get_vm_env_file` and refactored `vm_is_created` to use centralized resolution logic.

### V. Refactoring Rationale (The Refiner's Fire)
Centralizing path resolution in `vm_is_created` by calling `get_vm_env_file` and `get_vm_compose_file` prevents future drift and ensures DRY compliance.

### VI. Discussion Summary (The Signet's Record)
Identified naming mismatch between code expectation (`vde-name.env`) and physical files (`name.env`). Expanded fix to `vm_is_created` following code review.

### VII. Checklist of the Creed
- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified
- [x] Dual-Gate Review complete
- [x] Documentation updated

## Summary by Sourcery

Fix VM environment file resolution and centralize compose/env path detection for Spoke VMs.

Bug Fixes:
- Correct VM environment file name resolution so Spoke-specific .env files are properly located and loaded.
- Fix Spoke VM creation detection by aligning it with the corrected environment and compose file resolution logic.

Enhancements:
- Centralize environment and compose file path resolution in shared helpers to keep VM state checks consistent and DRY.