### PR TITLE
fix(armor): remediate Sourcery-AI findings for environment resolution

### DIFF
--- a/lib/vm-common
+++ b/lib/vm-common
@@ -577,7 +577,15 @@ get_vm_compose_file() {
 get_vm_env_file() {
     local raw_name
     raw_name=$(vde_normalize_name "${1}")
-    echo "env-files/${raw_name}.env"
+    local expected="env-files/${raw_name}.env"
+    local legacy="env-files/vde-${raw_name}.env"
+
+    if [[ -f "${VDE_ROOT_DIR}/${expected}" ]] && [[ -f "${VDE_ROOT_DIR}/${legacy}" ]]; then
+        # Log to stderr so it doesn't interfere with command substitution capturing stdout
+        vde_log_warn "Ambiguous environment files detected for ${raw_name}. Using ${expected}, ignoring legacy ${legacy}." "vde" >&2
+    fi
+
+    echo "${expected}"
 }
 
 # get_vm_image - Derives image name from Hub name
@@ -783,20 +791,32 @@ is_known_vm() {
     return ${VDE_ERR_NOT_FOUND}
 }
 
-# vm_is_created - Check if a VM has been created (config generated)
+# vde_validate_vm_assets - Validates existence of VM compose and env files
 # Args: <vm_name>
-# Returns: 0 if created (compose and env files exist), 1 otherwise
-vm_is_created() {
+# Returns: 0 if both exist, 1 if missing.
+vde_validate_vm_assets() {
     local vm_name="${1}"
     local compose_file
     compose_file=$(get_vm_compose_file "${vm_name}")
     local env_file
     env_file=$(get_vm_env_file "${vm_name}")
 
-    if [[ -f "${VDE_ROOT_DIR}/${compose_file}" ]] && [[ -f "${VDE_ROOT_DIR}/${env_file}" ]]; then
-        return 0
+    if [[ ! -f "${VDE_ROOT_DIR}/${compose_file}" ]]; then
+        return 1
     fi
-    return ${VDE_ERR_GENERAL}
+
+    if [[ ! -f "${VDE_ROOT_DIR}/${env_file}" ]]; then
+        return 1
+    fi
+
+    return 0
+}
+
+# vm_is_created - Check if a VM has been created (config generated)
+# Args: <vm_name>
+# Returns: 0 if created (compose and env files exist), 1 otherwise
+vm_is_created() {
+    vde_validate_vm_assets "${1}"
 }
 
 # vm_template_exists - Check if a VM template exists


### PR DESCRIPTION
### I. Context (The Why)
Addressing feedback from Sourcery-AI on PR #380 to improve robustness and maintainability.

### II. Signet Link (The Unbreakable Link)
Closes #381

### III. The Trial of the Gauntlet (Test Evidence)
- Verified ambiguity guard with manual test:
  ```
  2026-05-04T17:25:29-0400 [WARN ] [vde       ] Ambiguous environment files detected for rust. Using env-files/rust.env, ignoring legacy env-files/vde-rust.env.
  ```
- Proof of Life passed: 72/72 steps.

### IV. Files Changed (The Beskar Plates)
- `lib/vm-common`: Added `vde_validate_vm_assets` and updated `get_vm_env_file` with ambiguity guard.

### V. Refactoring Rationale (The Refiner's Fire)
Centralized existence semantics in `vde_validate_vm_assets` to satisfy the request for structured results in a Zsh-idiomatic way. Added warnings to prevent silent resolution ambiguity.

### VII. Checklist of the Creed
- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified
- [x] Dual-Gate Review complete
- [x] Documentation updated

## Summary by Sourcery

Improve VM environment resolution robustness by centralizing asset validation and guarding against ambiguous environment files.

Bug Fixes:
- Prevent silent selection of ambiguous VM environment files by emitting warnings and choosing a deterministic default.

Enhancements:
- Introduce a shared vde_validate_vm_assets helper to centralize environment asset existence checks for VM-related logic.