### PR TITLE
feat(armor): implement internal Spoke-to-Spoke SSH connectivity

### DIFF
--- a/bin/generate-all-configs
+++ b/bin/generate-all-configs
@@ -107,21 +107,29 @@ main() {
     # 3. Smelt SSH Configuration
     vde_log_info "Syncing SSH Pillar..." "ssh"
     local ssh_config="${VDE_ROOT_DIR}/configs/ssh/config"
+    local spoke_config="${VDE_ROOT_DIR}/configs/ssh/config.spoke"
     local current_version=$(vde_get_version)
     
-    {
-        echo "# VDE SSH Configuration"
-        echo "# Sovereign Baseline: ${current_version}"
-        echo "# DO NOT EDIT MANUALLY"
-        echo ""
-    } > "${ssh_config}"
+    local header="# VDE SSH Configuration
+# Sovereign Baseline: ${current_version}
+# DO NOT EDIT MANUALLY
+"
+    
+    echo "${header}" > "${ssh_config}"
+    echo "${header}" > "${spoke_config}"
 
     for vm_name in "${lang_vms[@]}" "${service_vms[@]}"; do
         local port="${VM_SSH_PORT[${vm_name}]}"
-        [[ -n "${port}" ]] && render_ssh_entry "${vm_name}" "${port}" >> "${ssh_config}"
+        if [[ -n "${port}" ]]; then
+            # Hub Config: uses 'localhost'
+            render_ssh_entry "${vm_name}" "${port}" "localhost" >> "${ssh_config}"
+            # Spoke Config: uses container name (e.g., vde-python)
+            local container_name=$(vde_get_ssh_host "${vm_name}")
+            render_ssh_entry "${vm_name}" "${port}" "${container_name}" >> "${spoke_config}"
+        fi
     done
     
-    chmod 600 "${ssh_config}"
+    chmod 600 "${ssh_config}" "${spoke_config}"
     vde_log_success "Sovereign Configuration Smelted Successfully." "smelter"
 }
 

--- a/bin/vde
+++ b/bin/vde
@@ -203,6 +203,13 @@ case ${ACTION} in
                 vde_run "${CANONICAL_NAME}" "${VDE_ROOT_DIR}/bin/vde-rebuild" "${BASE_NAME}" || continue
             fi
 
+            # DISCOVERY: Resolve the authoritative host SSH agent socket (Phase 31)
+            # This ensures the Spoke is linked to the VDE isolated agent, not the host default.
+            if [[ -z "${VDE_HOST_SSH_AUTH_SOCK:-}" ]]; then
+                export VDE_HOST_SSH_AUTH_SOCK=$(vde_get_host_ssh_sock)
+                vde_log_debug "Auto-discovered VDE_HOST_SSH_AUTH_SOCK: ${VDE_HOST_SSH_AUTH_SOCK}" "ssh"
+            fi
+
             # Canonical Ignition Handshake
             local vm_env_file
             vm_env_file=$(get_vm_env_file "${CANONICAL_NAME}")

--- a/configs/docker/vde-base.Dockerfile
+++ b/configs/docker/vde-base.Dockerfile
@@ -66,6 +66,10 @@ RUN mkdir -p /home/devuser/.ssh/vde && \
     chmod 700 /home/devuser/.ssh/vde && \
     chown -R devuser:devuser /home/devuser/.ssh
 
+# 5.1. Internal SSH Configuration (Lateral Bridge)
+COPY --chown=devuser:devuser configs/ssh/config.spoke /home/devuser/.ssh/config
+RUN chmod 600 /home/devuser/.ssh/config
+
 # 6. THE ATOMIC HANDSHAKE (Entrypoint)
 COPY scripts/vde-entrypoint.zsh /usr/local/bin/vde-entrypoint.zsh
 COPY scripts/vde-motd.zsh /usr/local/bin/vde-motd.zsh

--- a/configs/ssh/config.spoke
+++ b/configs/ssh/config.spoke
@@ -1,0 +1,388 @@
+# VDE SSH Configuration
+# Sovereign Baseline: 1.5.3
+# DO NOT EDIT MANUALLY
+
+# VDE VM: vde-asm
+# @shared-law (Sovereign Law)
+Host vde-asm
+    HostName vde-asm
+    Port 2200
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-c
+# @shared-law (Sovereign Law)
+Host vde-c
+    HostName vde-c
+    Port 2201
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-certified-ghost
+# @shared-law (Sovereign Law)
+Host vde-certified-ghost
+    HostName vde-certified-ghost
+    Port 2202
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-cpp
+# @shared-law (Sovereign Law)
+Host vde-cpp
+    HostName vde-cpp
+    Port 2203
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-csharp
+# @shared-law (Sovereign Law)
+Host vde-csharp
+    HostName vde-csharp
+    Port 2204
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-displaytest
+# @shared-law (Sovereign Law)
+Host vde-displaytest
+    HostName vde-displaytest
+    Port 2205
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-elixir
+# @shared-law (Sovereign Law)
+Host vde-elixir
+    HostName vde-elixir
+    Port 2206
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-flutter
+# @shared-law (Sovereign Law)
+Host vde-flutter
+    HostName vde-flutter
+    Port 2207
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-go
+# @shared-law (Sovereign Law)
+Host vde-go
+    HostName vde-go
+    Port 2208
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-haskell
+# @shared-law (Sovereign Law)
+Host vde-haskell
+    HostName vde-haskell
+    Port 2209
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-java
+# @shared-law (Sovereign Law)
+Host vde-java
+    HostName vde-java
+    Port 2210
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-js
+# @shared-law (Sovereign Law)
+Host vde-js
+    HostName vde-js
+    Port 2211
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-kotlin
+# @shared-law (Sovereign Law)
+Host vde-kotlin
+    HostName vde-kotlin
+    Port 2212
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-lamp
+# @shared-law (Sovereign Law)
+Host vde-lamp
+    HostName vde-lamp
+    Port 2213
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-lua
+# @shared-law (Sovereign Law)
+Host vde-lua
+    HostName vde-lua
+    Port 2214
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-mean
+# @shared-law (Sovereign Law)
+Host vde-mean
+    HostName vde-mean
+    Port 2215
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-php
+# @shared-law (Sovereign Law)
+Host vde-php
+    HostName vde-php
+    Port 2216
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-python
+# @shared-law (Sovereign Law)
+Host vde-python
+    HostName vde-python
+    Port 2217
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-ruby
+# @shared-law (Sovereign Law)
+Host vde-ruby
+    HostName vde-ruby
+    Port 2218
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-rust
+# @shared-law (Sovereign Law)
+Host vde-rust
+    HostName vde-rust
+    Port 2219
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-scala
+# @shared-law (Sovereign Law)
+Host vde-scala
+    HostName vde-scala
+    Port 2220
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-swift
+# @shared-law (Sovereign Law)
+Host vde-swift
+    HostName vde-swift
+    Port 2221
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-testport1
+# @shared-law (Sovereign Law)
+Host vde-testport1
+    HostName vde-testport1
+    Port 2222
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-testport2
+# @shared-law (Sovereign Law)
+Host vde-testport2
+    HostName vde-testport2
+    Port 2223
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-couchdb
+# @shared-law (Sovereign Law)
+Host vde-couchdb
+    HostName vde-couchdb
+    Port 2400
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-jupyterlab
+# @shared-law (Sovereign Law)
+Host vde-jupyterlab
+    HostName vde-jupyterlab
+    Port 2401
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-mongodb
+# @shared-law (Sovereign Law)
+Host vde-mongodb
+    HostName vde-mongodb
+    Port 2402
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-mysql
+# @shared-law (Sovereign Law)
+Host vde-mysql
+    HostName vde-mysql
+    Port 2403
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-nginx
+# @shared-law (Sovereign Law)
+Host vde-nginx
+    HostName vde-nginx
+    Port 2404
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-postgres
+# @shared-law (Sovereign Law)
+Host vde-postgres
+    HostName vde-postgres
+    Port 2405
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-rabbitmq
+# @shared-law (Sovereign Law)
+Host vde-rabbitmq
+    HostName vde-rabbitmq
+    Port 2406
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes
+# VDE VM: vde-redis
+# @shared-law (Sovereign Law)
+Host vde-redis
+    HostName vde-redis
+    Port 2407
+    User devuser
+    IdentityFile ~/.ssh/vde/vde_student
+    UserKnownHostsFile ~/.ssh/vde/known_hosts
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    ForwardAgent yes
+    RequestTTY yes

--- a/lib/vde-templates
+++ b/lib/vde-templates
@@ -96,16 +96,17 @@ render_service_template() {
     echo "${content}"
 }
 
-# render_ssh_entry VM_NAME PORT
+# render_ssh_entry VM_NAME PORT [HOSTNAME]
 # Render SSH config entry for VM
 render_ssh_entry() {
-    local vm_name="${1}" port="${2}"
+    local vm_name="${1}" port="${2}" hostname="${3:-localhost}"
     local host
     host="$(vde_get_ssh_host "${vm_name}")"
 
     # Use '~' for paths to avoid absolute path leaks in the audit
     render_template "${TEMPLATES_DIR}/ssh-config.tmpl" \
         SSH_HOST "${host}" SSH_PORT "${port}" \
+        HOST_NAME "${hostname}" \
         IDENTITY_FILE "~/.ssh/vde/vde_student" \
         KNOWN_HOSTS_FILE "~/.ssh/vde/known_hosts" \
         COMMENT "VDE VM: ${vm_name}"

--- a/templates/ssh-config.tmpl
+++ b/templates/ssh-config.tmpl
@@ -1,7 +1,7 @@
 # {{COMMENT}}
 # @shared-law (Sovereign Law)
 Host {{SSH_HOST}}
-    HostName localhost
+    HostName {{HOST_NAME}}
     Port {{SSH_PORT}}
     User devuser
     IdentityFile {{IDENTITY_FILE}}

--- a/tests/features/core-infrastructure/spoke-to-spoke-ssh.feature
+++ b/tests/features/core-infrastructure/spoke-to-spoke-ssh.feature
@@ -1,0 +1,23 @@
+# VDE ARCHITECTURAL RECORD
+# @forge (Governance Sentinel)
+@core-infrastructure @ssh @spoke-to-spoke
+Feature: Spoke-to-Spoke SSH Connectivity
+  As an Alor of the VDE
+  I require empirical proof of internal SSH connectivity between Spokes
+  So that tech stacks can utilize secure transversal communication autonomously
+
+  Background: Core Spokes are Active
+    Given the VDE system is healthy
+    And "python" is running
+    And "rust" is running
+
+  Scenario: Empirical Proof: Internal SSH Handshake
+    When I execute "ssh -o BatchMode=yes -o StrictHostKeyChecking=no vde-python echo 'SSH_SUCCESS'" inside "rust"
+    Then the exit code should be 0
+    And the output should contain "SSH_SUCCESS"
+
+  Scenario: Integrity Audit: Internal SSH Configuration
+    When I execute "cat /home/devuser/.ssh/config" inside "rust"
+    Then the output should contain "Host vde-python"
+    And the output should contain "HostName vde-python"
+    And the output should contain "IdentityFile ~/.ssh/vde/vde_student"


### PR DESCRIPTION
### I. Context (The Why)
Enabling Spokes to communicate with each other via SSH autonomously. This is critical for multi-VM tech stacks and secure transversal bridge testing.

### II. Signet Link (The Unbreakable Link)
Closes #391

### III. The Trial of the Gauntlet (Test Evidence)
- Verified with new BDD feature `spoke-to-spoke-ssh.feature`:
  ```
  1 feature passed, 0 failed, 0 skipped
  2 scenarios passed, 0 failed, 0 skipped
  13 steps passed, 0 failed, 0 skipped
  ```
- Empirical terminal proof:
  ```
  Warning: Permanently added '[vde-python]:2217' (ED25519) to the list of known hosts.
  Spoke-to-Spoke SSH Success
  ```

### IV. Files Changed (The Beskar Plates)
- `templates/ssh-config.tmpl`: Dynamic `HostName`.
- `lib/vde-templates`: Pass `hostname` to renderer.
- `bin/generate-all-configs`: Generate `config.spoke` using container hostnames.
- `configs/docker/vde-base.Dockerfile`: Bake Spoke config into image.
- `bin/vde`: Auto-discover and export `VDE_HOST_SSH_AUTH_SOCK` during ignition.
- `tests/features/core-infrastructure/spoke-to-spoke-ssh.feature`: Empirical verification.

### V. Refactoring Rationale (The Refiner's Fire)
Separating Hub and Spoke SSH configurations ensures that internal Spoke-to-Spoke resolution doesn't rely on Hub port-mapping, improving stability and portability.

### VII. Checklist of the Creed
- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified
- [x] Dual-Gate Review complete
- [x] Documentation updated

## Summary by Sourcery

Enable internal SSH connectivity between Spoke containers using dedicated SSH configs and updated VDE tooling.

New Features:
- Introduce a Spoke-specific SSH configuration that targets container hostnames instead of localhost.
- Support internal Spoke-to-Spoke SSH communication for multi-VM tech stacks.

Enhancements:
- Update SSH config templating to accept a dynamic host name field.
- Bake the Spoke SSH config into the base VDE Docker image for automatic availability.
- Enhance VDE tooling to generate and wire Spoke SSH configs and discover SSH agent sockets during startup.

Tests:
- Add a BDD feature validating Spoke-to-Spoke SSH handshakes and SSH config integrity inside Spoke containers.