### PR TITLE
feat(armor): add Next Steps guidance for students and new hires

### DIFF
--- a/bin/add-vm-type
+++ b/bin/add-vm-type
@@ -300,8 +300,4 @@ if [[ "${QUIET}" == "false" ]]; then
 fi
 
 log_success "VM type '${VM_NAME}' added successfully!"
-echo ""
-echo "Next steps:"
-echo "  1. Create the VM: vde create ${VM_NAME}"
-echo "  2. Start the VM:  vde start ${VM_NAME}"
-echo ""
+vde_print_next_steps "add" "${VM_NAME}"

--- a/bin/vde
+++ b/bin/vde
@@ -179,6 +179,7 @@ case ${ACTION} in
 
             if is_vm_running "${CANONICAL_NAME}"; then
                 vde_log_info "${CANONICAL_NAME} is already running." "docker"
+                vde_print_next_steps "start" "${CANONICAL_NAME}"
                 continue
             fi
 
@@ -238,6 +239,7 @@ case ${ACTION} in
 
             if vde_run "${CANONICAL_NAME}" "${compose_up_cmd[@]}" >/dev/null 2>&1; then
                 vde_progress_spinner_stop "${CANONICAL_NAME} ignited"
+                vde_print_next_steps "start" "${CANONICAL_NAME}"
             else
                 vde_progress_spinner_stop "" "Failed to ignite ${CANONICAL_NAME}" 1
                 GLOBAL_RC=1
@@ -250,6 +252,7 @@ case ${ACTION} in
     stop)
         [[ -z "${targets}" ]] && vde_log_error "Usage: vde stop [-f] <alias...|default|all>" && exit ${VDE_ERR_GENERAL}
 
+        local last_stopped=""
         for vm_alias in "${targets[@]}"; do
             local CANONICAL_NAME=$(resolve_vm_name "${vm_alias}" 2>/dev/null)
             if [[ -z "${CANONICAL_NAME}" ]]; then
@@ -261,6 +264,7 @@ case ${ACTION} in
                 vde_progress_spinner_start "Stopping ${CANONICAL_NAME}"
                 if vde_run "${CANONICAL_NAME}" docker stop "${CANONICAL_NAME}" >/dev/null 2>&1; then
                     vde_progress_spinner_stop "${CANONICAL_NAME} stopped"
+                    last_stopped="${CANONICAL_NAME}"
                 else
                     vde_progress_spinner_stop "" "Failed to stop ${CANONICAL_NAME}" 1
                 fi
@@ -268,11 +272,13 @@ case ${ACTION} in
                 vde_log_info "${CANONICAL_NAME} is not running." "vde"
             fi
         done
+        [[ -n "${last_stopped}" ]] && vde_print_next_steps "stop" "${last_stopped}"
         ;;
 
     restart)
         [[ -z "${targets}" ]] && vde_log_error "Usage: vde restart <alias...|default|all>" && exit ${VDE_ERR_GENERAL}
         
+        local last_restarted=""
         for vm_alias in "${targets[@]}"; do
             local CANONICAL_NAME=$(resolve_vm_name "${vm_alias}" 2>/dev/null)
             if [[ -z "${CANONICAL_NAME}" ]]; then
@@ -286,15 +292,18 @@ case ${ACTION} in
             fi
             if ./bin/vde start "${CANONICAL_NAME}" >/dev/null 2>&1; then
                 vde_progress_spinner_stop "${CANONICAL_NAME} restarted"
+                last_restarted="${CANONICAL_NAME}"
             else
                 vde_progress_spinner_stop "" "Failed to restart ${CANONICAL_NAME}" 1
             fi
         done
+        [[ -n "${last_restarted}" ]] && vde_print_next_steps "restart" "${last_restarted}"
         ;;
 
     remove|delete|rm)
         [[ -z "${targets}" ]] && vde_log_error "Usage: vde remove <alias...|default|all>" && exit ${VDE_ERR_GENERAL}
 
+        local last_removed=""
         for vm_alias in "${targets[@]}"; do
             local CANONICAL_NAME=$(resolve_vm_name "${vm_alias}" 2>/dev/null)
             if [[ -z "${CANONICAL_NAME}" ]]; then
@@ -306,6 +315,7 @@ case ${ACTION} in
                 vde_progress_spinner_start "Removing container ${CANONICAL_NAME}"
                 if vde_run "${CANONICAL_NAME}" docker rm -f "${CANONICAL_NAME}" >/dev/null 2>&1; then
                     vde_progress_spinner_stop "${CANONICAL_NAME} removed"
+                    last_removed="${CANONICAL_NAME}"
                 else
                     vde_progress_spinner_stop "" "Failed to remove ${CANONICAL_NAME}" 1
                 fi
@@ -313,6 +323,7 @@ case ${ACTION} in
                 vde_log_info "No container found for ${CANONICAL_NAME}." "vde"
             fi
         done
+        [[ -n "${last_removed}" ]] && vde_print_next_steps "rm" "${last_removed}"
         ;;
 
     nuke)

--- a/bin/vde-init
+++ b/bin/vde-init
@@ -34,6 +34,7 @@ export VDE_ROOT_DIR
 [[ -f "${VDE_ROOT_DIR}/lib/vde-errors" ]] && source "${VDE_ROOT_DIR}/lib/vde-errors" &>/dev/null
 [[ -f "${VDE_ROOT_DIR}/lib/vde-log" ]] && source "${VDE_ROOT_DIR}/lib/vde-log" &>/dev/null
 [[ -f "${VDE_ROOT_DIR}/lib/vde-security" ]] && source "${VDE_ROOT_DIR}/lib/vde-security" &>/dev/null
+[[ -f "${VDE_ROOT_DIR}/lib/vde-core" ]] && source "${VDE_ROOT_DIR}/lib/vde-core" &>/dev/null
 
 # Initialize security environment (network, permissions)
 vde_security_init
@@ -515,6 +516,7 @@ else
         echo "╚════════════════════════════════════════════════════════════╝"
         echo ""
         vde_init_show_status
+        vde_print_next_steps "init"
     fi
 fi
 

--- a/bin/vde-rebuild
+++ b/bin/vde-rebuild
@@ -280,3 +280,10 @@ done
 
 echo ""
 echo "Done!"
+
+# Show Next Steps for the last rebuilt spoke (or base if no spokes)
+if [[ ${#spokes[@]} -gt 0 ]]; then
+    vde_print_next_steps "rebuild" "${spokes[-1]}"
+else
+    vde_print_next_steps "create"
+fi

--- a/lib/vde-core
+++ b/lib/vde-core
@@ -977,3 +977,82 @@ vde_time_end() {
         fi
     fi
 }
+
+#===============================================================================
+# Next Steps Helper - Guidance for Students and New Hires
+#===============================================================================
+# Displays contextual next steps based on the command just executed.
+# Always ends with 'vde list' as the final suggestion.
+#
+# Usage: vde_print_next_steps <command_type> [vm_name]
+#
+# Examples:
+#   vde_print_next_steps "init"
+#   vde_print_next_steps "start" "python"
+#   vde_print_next_steps "rm" "python"
+#===============================================================================
+vde_print_next_steps() {
+    local cmd_type="${1:-}"
+    local vm_name="${2:-}"
+    local vm_alias="${vm_name#vde-}"
+
+    echo ""
+    echo "Next:"
+
+    case "${cmd_type}" in
+        init)
+            echo "  vde create <name>  - forge your first VM (e.g., vde create python)"
+            ;;
+        create|rebuild)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde start ${vm_alias}   - ignite your VM"
+            else
+                echo "  vde start <name>   - ignite your VM"
+            fi
+            ;;
+        start)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde enter ${vm_alias}   - enter your VM"
+            else
+                echo "  vde enter <name>   - enter your VM"
+            fi
+            ;;
+        stop)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde start ${vm_alias}   - re-ignite your VM"
+            else
+                echo "  vde start <name>   - re-ignite your VM"
+            fi
+            ;;
+        rm|remove)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde create ${vm_alias}  - re-forge your VM"
+            else
+                echo "  vde create <name>  - re-forge your VM"
+            fi
+            ;;
+        add)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde create ${vm_alias}  - forge the new VM type"
+            else
+                echo "  vde create <name>  - forge the new VM type"
+            fi
+            ;;
+        uninstall)
+            echo "  vde create <name>  - forge a new VM type"
+            ;;
+        restart)
+            if [[ -n "${vm_alias}" ]]; then
+                echo "  vde enter ${vm_alias}   - enter your VM"
+            else
+                echo "  vde enter <name>   - enter your VM"
+            fi
+            ;;
+        *)
+            # Generic fallback
+            echo "  vde help           - view all commands"
+            ;;
+    esac
+
+    echo "  vde list           - list status of all created Spokes"
+}

--- a/tests/features/student-guidance/next-steps-guidance.feature
+++ b/tests/features/student-guidance/next-steps-guidance.feature
@@ -1,0 +1,84 @@
+# VDE ARCHITECTURAL RECORD
+# @armor (Student Guidance)
+Feature: Next Steps Guidance for Students and New Hires
+  As a new student or hire using VDE
+  I want clear guidance on what to do next after each command
+  So I can efficiently navigate the VDE workflow
+
+  Background: The Tetrad is Active
+    Given the 4 Pillars (Zsh, Git, Docker, SSH) have passed their individual proofs
+    And the Hub is synchronized to version 1.5.3
+    And I execute "bin/vde uninstall vde-dynamic-vm --skip-confirm"
+    And I execute "rm -rf .locks/global-config.lock"
+
+  Scenario: After init, student sees guidance to create first VM
+    When I execute "bin/vde init"
+    Then the output should contain "VDE Initialization Complete!"
+    And the output should contain "Next:"
+    And the output should contain "vde create"
+    And the output should contain "vde list"
+
+  Scenario: After create, student sees guidance to start VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    When I execute "bin/vde create python"
+    Then the Docker image "vde-python" should exist on the Hub
+    And the output should contain "Next:"
+    And the output should contain "vde start python"
+    And the output should contain "vde list"
+
+  Scenario: After start, student sees guidance to enter VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    When I execute "bin/vde start python"
+    Then a container named "vde-python" should be running
+    And the output should contain "Next:"
+    And the output should contain "vde enter python"
+    And the output should contain "vde list"
+
+  Scenario: After stop, student sees guidance to restart VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    And I execute "bin/vde start python"
+    When I execute "bin/vde stop python"
+    Then the container "vde-python" should not be running
+    And the output should contain "Next:"
+    And the output should contain "vde start python"
+    And the output should contain "vde list"
+
+  Scenario: After rm, student sees guidance to recreate VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    And I execute "bin/vde start python"
+    And I execute "bin/vde stop python"
+    When I execute "bin/vde rm python"
+    Then the container "vde-python" should not exist
+    And the output should contain "Next:"
+    And the output should contain "vde create python"
+    And the output should contain "vde list"
+
+  Scenario: After restart, student sees guidance to enter VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    And I execute "bin/vde start python"
+    When I execute "bin/vde restart python"
+    Then the container "vde-python" should be running
+    And the output should contain "Next:"
+    And the output should contain "vde enter python"
+    And the output should contain "vde list"
+
+  Scenario: After rebuild, student sees guidance to start VM
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    When I execute "bin/vde rebuild python"
+    Then the Docker image "vde-python" should exist on the Hub
+    And the output should contain "Next:"
+    And the output should contain "vde start python"
+    And the output should contain "vde list"
+
+  Scenario: vde list is always the final suggestion
+    Given I have a valid VM definition for "python" in the Beskar Registry
+    And I execute "bin/vde create python"
+    When I execute "bin/vde start python"
+    Then the output should contain "vde list"
+    When I execute "bin/vde stop python"
+    Then the output should contain "vde list"


### PR DESCRIPTION
## Summary
- Adds contextual "Next Steps" guidance for students and new hires at the end of every lifecycle command
- Introduces `vde_print_next_steps()` helper function in `lib/vde-core`
- Always displays `vde list` as the final suggestion for discoverability

## Changes

### Core Implementation
- **lib/vde-core**: New `vde_print_next_steps()` function that provides contextual guidance based on the command just executed

### Command Integration
- **bin/vde**: Integrated Next Steps into `start`, `stop`, `rm`, and `restart` commands
- **bin/vde-init**: Shows guidance after initialization completes
- **bin/vde-rebuild**: Shows guidance after rebuild finishes
- **bin/add-vm-type**: Shows guidance after VM type registration

### Testing
- **tests/features/student-guidance/next-steps-guidance.feature**: BDD tests covering all 8 scenarios (88 steps)

## Example Output
\`\`\`
$ vde start python
✓ vde-python ignited

Next:
  vde enter python   - enter your VM
  vde list           - list status of all created Spokes
\`\`\`

## Test Results
| Feature | Scenarios | Steps | Status |
|---------|-----------|-------|--------|
| Next Steps Guidance | 8/8 | 88/88 | ✅ PASS |
| Proof of Life | 6/6 | 72/72 | ✅ PASS |

Closes #397

## Summary by Sourcery

Add contextual Next Steps guidance after key VDE lifecycle commands to improve onboarding for students and new hires.

New Features:
- Introduce a shared helper in vde-core to print contextual Next Steps guidance based on the last executed command.
- Display Next Steps guidance after init, create, start, stop, rm, restart, rebuild, and related VM lifecycle commands, always including a final vde list suggestion.

Tests:
- Add a BDD feature suite covering Next Steps guidance scenarios across the VDE lifecycle for student and new-hire workflows.