### PR TITLE
fix(armor): prevent ssh-agent orphan process leaks

### DIFF
--- a/bin/ssh-setup
+++ b/bin/ssh-setup
@@ -49,6 +49,7 @@ Actions:
               Use --force or -f to regenerate existing keys
   start     Start SSH agent and load VDE key
   stop      Stop VDE-specific SSH agent
+  cleanup   Kill all transient ssh-agent processes (preserves VDE shared agent)
   autostart Configure shell to auto-start SSH agent on login
   generate  Regenerate VM SSH config only
 
@@ -59,6 +60,7 @@ Examples:
   vde ssh-setup init --force # Force regenerate keys
   vde ssh-setup start        # Start agent and load keys
   vde ssh-setup stop         # Stop the VDE-specific agent
+  vde ssh-setup cleanup      # Kill orphaned/transient ssh-agents
   vde ssh-setup autostart    # Auto-start agent on shell login
   vde ssh-setup generate     # Regenerate SSH config for VMs
 
@@ -301,11 +303,56 @@ if [[ "${ACTION}" == "generate" ]] ; then
 fi
 
 # ==============================================================================
-# Autostart Mode -- Configure shell to auto-start SSH agent
+# Cleanup Mode -- Kill all transient ssh-agents (preserve VDE shared agent)
+# ==============================================================================
+if [[ "${ACTION}" == "cleanup" ]] ; then
+    echo ""
+    echo "Cleaning up transient ssh-agent processes..."
+    echo ""
+    
+    local vde_agent_pid=""
+    local vde_agent_env="${VDE_SSH_DIR}/agent_env"
+    local killed=0
+    local preserved=0
+    
+    # Get VDE's shared agent PID to preserve it
+    if [[ -f "${vde_agent_env}" ]]; then
+        vde_agent_pid=$(grep "^SSH_AGENT_PID=" "${vde_agent_env}" 2>/dev/null | sed 's/SSH_AGENT_PID=\([0-9]*\).*/\1/')
+    fi
+    
+    if [[ -n "${vde_agent_pid}" ]]; then
+        echo "VDE shared agent PID: ${vde_agent_pid} (will be preserved)"
+    fi
+    
+    # Find and kill all ssh-agent processes
+    while IFS= read -r pid; do
+        [[ -z "${pid}" ]] && continue
+        if [[ "${pid}" == "${vde_agent_pid}" ]]; then
+            log_info "Preserving VDE shared agent: ${pid}"
+            ((preserved++))
+            continue
+        fi
+        echo "  Killing transient ssh-agent PID ${pid}"
+        kill "${pid}" 2>/dev/null && ((killed++))
+    done < <(pgrep -x ssh-agent 2>/dev/null)
+    
+    echo ""
+    if [[ ${killed} -gt 0 ]]; then
+        log_success "Killed ${killed} transient ssh-agent(s)"
+    else
+        log_info "No transient ssh-agents found"
+    fi
+    [[ ${preserved} -gt 0 ]] && log_info "Preserved ${preserved} VDE shared agent(s)"
+    
+    exit ${VDE_SUCCESS}
+fi
+
+# ==============================================================================
+# Autostart Mode -- Configure shell to auto-start SSH agent (VDE Isolated)
 # ==============================================================================
 if [[ "${ACTION}" == "autostart" ]] ; then
     echo ""
-    echo "Configuring shell to auto-start SSH agent..."
+    echo "Configuring shell to auto-start VDE SSH agent..."
     echo ""
 
     # Detect shell config file (ZSH ONLY - UAP Mandate 1)
@@ -313,9 +360,18 @@ if [[ "${ACTION}" == "autostart" ]] ; then
 
     # Marker for our addition
     local marker="# VDE SSH Agent Auto-Start"
+    
+    # Use VDE's centralized agent management to prevent orphaned agents
+    # This ensures only ONE agent is shared across all shells
     local entry="${marker}
-if [[ -f \"${VDE_SSH_IDENTITY}\" ]] ; then
-    eval \$(ssh-agent -s) 2>/dev/null
+# VDE SSH Agent - Uses centralized agent to prevent orphans
+if [[ -f \"${VDE_SSH_DIR}/agent_env\" ]]; then
+    source \"${VDE_SSH_DIR}/agent_env\" >/dev/null 2>&1
+fi
+if [[ -z \"\${SSH_AUTH_SOCK:-}\" ]] || [[ ! -S \"\${SSH_AUTH_SOCK}\" ]]; then
+    # No agent running - start VDE isolated agent
+    (umask 077; ssh-agent -s > \"${VDE_SSH_DIR}/agent_env\")
+    source \"${VDE_SSH_DIR}/agent_env\" >/dev/null 2>&1
     ssh-add \"${VDE_SSH_IDENTITY}\" 2>/dev/null
 fi"
 
@@ -331,6 +387,7 @@ fi"
 
     echo ""
     echo "VDE SSH agent will now auto-start on new shell sessions."
+    echo "Uses centralized agent at ${VDE_SSH_DIR}/agent_env to prevent orphans."
     echo "To apply to current shell, run:"
     echo "  source ${shell_config}"
     exit ${VDE_SUCCESS}
@@ -341,6 +398,6 @@ fi
 # ==============================================================================
 echo "Unknown action: ${ACTION}"
 echo ""
-echo "Valid actions: status, init, start, autostart, generate"
+echo "Valid actions: status, init, start, stop, cleanup, autostart, generate"
 echo "Run 'vde ssh-setup --help' for usage information"
 exit ${VDE_ERR_GENERAL}

--- a/tests/lib/docker-test-utils.zsh
+++ b/tests/lib/docker-test-utils.zsh
@@ -69,6 +69,38 @@ kill_orphan_ssh_agents() {
     return 0
 }
 
+# kill_all_transient_ssh_agents
+# Kills ALL ssh-agent processes except the VDE shared agent.
+# Use this for aggressive cleanup when orphaned agents accumulate.
+kill_all_transient_ssh_agents() {
+    local vde_agent_pid=""
+    local vde_agent_env="${VDE_SSH_DIR:-${HOME}/.ssh/vde}/agent_env"
+    local killed=0
+    local preserved=0
+    
+    # Get VDE's shared agent PID to preserve it
+    if [[ -f "${vde_agent_env}" ]]; then
+        vde_agent_pid=$(grep "^SSH_AGENT_PID=" "${vde_agent_env}" 2>/dev/null | sed 's/SSH_AGENT_PID=\([0-9]*\).*/\1/')
+    fi
+    
+    echo "[CLEANUP] Scanning for ssh-agent processes..."
+    [[ -n "${vde_agent_pid}" ]] && echo "[CLEANUP] Preserving VDE agent PID ${vde_agent_pid}"
+    
+    while IFS= read -r pid; do
+        [[ -z "${pid}" ]] && continue
+        if [[ "${pid}" == "${vde_agent_pid}" ]]; then
+            echo "[CLEANUP]   Preserving VDE shared agent: ${pid}"
+            ((preserved++))
+            continue
+        fi
+        echo "[CLEANUP]   Killing transient ssh-agent PID ${pid}"
+        kill "${pid}" 2>/dev/null && ((killed++))
+    done < <(pgrep -x ssh-agent 2>/dev/null)
+    
+    echo "[CLEANUP] Killed ${killed} transient ssh-agent(s), preserved ${preserved} VDE agent(s)"
+    return 0
+}
+
 # kill_orphan_test_sessions
 # Kills zsh processes running vde test scripts that have been running > 10 min.
 # Prevents accumulation of stuck/disconnected test sessions.
@@ -315,14 +347,30 @@ docker_test_teardown() {
 # Full container sweep for safety
 cleanup_vde_containers
 
-# Note: We do NOT kill the agent here anymore if we want to reuse it
-# across the entire suite. The main suite runner (run-full-test-suite.zsh)
-# or the setup-ssh-agent.zsh --cleanup will handle final termination.
-if [[ -n "${_DOCKER_TEST_AGENT_PID}" ]]; then
-    echo "[TEARDOWN] Released VDE ssh-agent reference (PID ${_DOCKER_TEST_AGENT_PID})"
+# Kill the SSH agent we started (unless it's a shared VDE agent)
+# Only kill agents we started ourselves via the fallback path
+if [[ -n "${_DOCKER_TEST_AGENT_PID}" ]] && [[ -n "${_DOCKER_TEST_AGENT_SOCK}" ]]; then
+    # Check if this is the VDE centralized agent or a fallback agent
+    local vde_agent_env="${VDE_SSH_DIR:-${HOME}/.ssh/vde}/agent_env"
+    local is_vde_agent=0
+    
+    if [[ -f "${vde_agent_env}" ]]; then
+        local env_pid
+        env_pid=$(grep "^SSH_AGENT_PID=" "${vde_agent_env}" 2>/dev/null | sed 's/SSH_AGENT_PID=\([0-9]*\).*/\1/')
+        [[ "${env_pid}" == "${_DOCKER_TEST_AGENT_PID}" ]] && is_vde_agent=1
+    fi
+    
+    if [[ ${is_vde_agent} -eq 0 ]]; then
+        # This is a fallback agent we started - kill it
+        echo "[TEARDOWN] Killing fallback ssh-agent (PID ${_DOCKER_TEST_AGENT_PID})"
+        kill "${_DOCKER_TEST_AGENT_PID}" 2>/dev/null || true
+        [[ -S "${_DOCKER_TEST_AGENT_SOCK}" ]] && rm -f "${_DOCKER_TEST_AGENT_SOCK}" 2>/dev/null
+    else
+        echo "[TEARDOWN] Preserving VDE shared ssh-agent (PID ${_DOCKER_TEST_AGENT_PID})"
+    fi
 fi
 
-# Kill any remaining remaining test artifacts (not the agent)
+# Kill any remaining test artifacts
 kill_orphan_test_sessions
 
 


### PR DESCRIPTION
## Summary

Fixes ssh-agent orphan process accumulation that was causing multiple transient `ssh-agent -s` processes to be left running on the host.

## Problem

Transient ssh-agent processes were being orphaned and accumulating:
```
dderyldowney  9578   0.0  0.0 34282416   1940   ??  Ss    6:53PM   0:00.01 ssh-agent -s
dderyldowney  8871   0.0  0.0 34269104   1152   ??  Ss    6:52PM   0:00.00 ssh-agent -s
dderyldowney 72489   0.0  0.0 34272160    680   ??  Ss    5:41PM   0:00.00 ssh-agent -s
...
```

## Root Causes

1. **`tests/lib/docker-test-utils.zsh:318-322`** - Teardown intentionally skipped agent cleanup, referencing non-existent cleanup scripts
2. **`bin/ssh-setup autostart`** - Used `eval $(ssh-agent -s)` which spawns a NEW agent on every shell session
3. **Missing cleanup utility** - No way to clean up accumulated orphaned agents

## Solution

### 1. Fixed Test Teardown (`tests/lib/docker-test-utils.zsh`)
- Added proper agent cleanup in `docker_test_teardown()`
- Kills fallback agents while preserving VDE shared agent
- Added `kill_all_transient_ssh_agents()` utility function

### 2. Fixed Autostart (`bin/ssh-setup`)
- Changed from spawning new agent per shell to using centralized VDE agent
- Now sources `~/.ssh/vde/agent_env` to reuse existing agent
- Only starts new agent if none exists

### 3. Added Cleanup Command (`bin/ssh-setup cleanup`)
- New `vde ssh-setup cleanup` command
- Kills all transient ssh-agent processes
- Preserves VDE shared agent

## Files Modified

- `tests/lib/docker-test-utils.zsh` - Fixed teardown, added cleanup utilities (+60 lines)
- `bin/ssh-setup` - Fixed autostart, added cleanup action (+67 lines)

## Testing

```
1 feature passed, 0 failed, 0 skipped
6 scenarios passed, 0 failed, 0 skipped
72 steps passed, 0 failed, 0 skipped
Took 1m 14.459s
```

**Verified:** Only 1 ssh-agent remains after fix (VDE shared agent PID 9578)

Closes #399

## Summary by Sourcery

Prevent accumulation of orphan ssh-agent processes by tightening test teardown and improving ssh agent lifecycle management.

Bug Fixes:
- Ensure docker test teardown terminates fallback ssh-agent instances while preserving the shared VDE agent.
- Avoid leaving multiple transient ssh-agent processes running across shells and test runs.

Enhancements:
- Add a utility to aggressively clean up all transient ssh-agent processes while preserving the shared VDE agent.
- Update ssh-setup behavior to rely on a centralized VDE ssh-agent when available instead of always spawning a new one.