### PR TITLE
fix(docs): correct docs/operations/ to match implementation

### DIFF
--- a/docs/operations/mcp-configuration.md
+++ b/docs/operations/mcp-configuration.md
@@ -3,20 +3,20 @@
 
 ## Overview
 
-This document describes the MCP (Model Context Protocol) server configuration for the VDE project. MCP servers extend the capabilities of the Gemini CLI by providing specialized tools for various tasks.
+This document describes the MCP (Model Context Protocol) server configuration for the VDE project. MCP servers extend the capabilities of AI agents by providing specialized tools for various tasks.
 
-> **MANDATE**: All agents MUST utilize these connected MCP servers as their primary interface for system interaction. Documentation updates and technical queries MUST utilize `context7` and `gemini-docs-mcp`.
+> **MANDATE**: All agents MUST utilize connected MCP servers as their primary interface for system interaction. Documentation updates and technical queries MUST utilize `context7`.
 
 ## Configuration Location
 
-The project-specific MCP configuration is located at:
+The project-specific Kilo configuration is located at:
 ```
-.gemini/settings.json
+kilo.json
 ```
 
 Global configuration can be found at:
 ```
-~/.gemini/settings.json
+~/.config/kilo/settings.json
 ```
 
 ## Configured Services
@@ -24,102 +24,42 @@ Global configuration can be found at:
 | Service | Purpose | Status |
 |---------|---------|--------|
 | `context7` | Up-to-date documentation and code examples | ✅ Configured |
-| `gemini-docs-mcp` | Gemini API and CLI documentation | ✅ Configured |
-| `MCP_DOCKER` | Docker operations and gateway | ✅ Configured |
+| `github` | GitHub repository and issue management | ✅ Configured |
 
-## Configuration File (.gemini/settings.json)
+## context7
 
-```json
-{
-  "mcp": {
-    "allowed": [
-      "context7",
-      "gemini-docs-mcp",
-      "MCP_DOCKER",
-      "github",
-      "redis",
-      "firebase",
-      "google-workspace"
-    ]
-  },
-  "mcpServers": {
-    "context7": {
-      "timeout": 60000,
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
-    },
-    "MCP_DOCKER": {
-      "command": "docker",
-      "args": ["mcp", "gateway", "run"]
-    }
-  }
-}
-```
+Context7 provides up-to-date documentation and code examples. It is configured to run via `npx`. Ensure you have an internet connection for the first run.
 
-## Setup Instructions
-
-### 1. Context7 Setup
-
-Context7 provides up-to-date documentation. It is configured to run via `npx`. Ensure you have an internet connection for the first run.
-
-### 2. Redis MCP Server
-
-The Redis MCP server can be configured via `uvx` or `docker`. For VDE, we prefer the Docker-based approach for isolation:
-
-```zsh
-gemini mcp add redis docker run --rm --name redis-mcp-server -i -e REDIS_URL=redis://localhost:6379/0 mcp-redis
-```
-
-### 3. GitHub Token Setup
-
-The GitHub MCP server requires a personal access token:
-
-1. Generate a GitHub Personal Access Token:
-   - Go to: https://github.com/settings/tokens
-   - Create token with scopes: `repo`, `read:org`, `read:user`
-
-2. Set the environment variable:
-   ```zsh
-   export GITHUB_TOKEN="your_token_here"
-   ```
-
-## Service Details
-
-### context7
 - **Package:** `@upstash/context7-mcp`
 - **Purpose:** Prevents outdated or hallucinated API responses by providing real-time documentation.
 - **Usage:** "Researcher, use context7 to find the latest Next.js routing patterns."
 
-### gemini-docs-mcp
-- **Purpose:** Specialized documentation for Gemini API and CLI features.
-- **Usage:** Must be used before any Gemini API integration.
+## GitHub MCP
 
-### redis-mcp-server
-- **Package:** `mcp-redis`
-- **Purpose:** Natural language interface for managing and searching data in Redis.
-- **Usage:** "Database Admin, check the user session cache in Redis."
+The GitHub MCP server provides access to repository management, issues, PRs, and code search.
 
-### MCP_DOCKER
-- **Purpose:** Bridge between the CLI and Docker runtime for VM management.
+- **Purpose:** GitHub lifecycle automation (Issues, PRs, code search, repository management)
+- **Requirement:** `gh` CLI authenticated and active
+
+---
 
 ## Troubleshooting
 
 ### Check Configuration
+
 ```zsh
-cat .gemini/settings.json | jq .
+cat kilo.json | python3 -m json.tool
 ```
 
-### Test Individual Server
+### Verify context7 Connectivity
+
 ```zsh
-npx -y @modelcontextprotocol/server-[name]
+npx -y @upstash/context7-mcp@latest --help
 ```
 
-### Clear NPX Cache (if issues)
-```zsh
-npm cache clean --force
-```
+---
 
 ## References
 
-- [MCP Implementation Plan](../plans/specs/mcp-implementation-plan.md)
-- [Kilo Code MCP Rules](../../../.gemini/RULES/tools_mcp.md)
+- [Kilo Documentation](https://kilo.ai/docs)
+- [Context7 Documentation](https://github.com/upstash/context7-mcp)

--- a/docs/operations/rebuild-guidelines.md
+++ b/docs/operations/rebuild-guidelines.md
@@ -97,24 +97,29 @@ vde rebuild --no-cache all
 ## Troubleshooting Rebuilds
 
 ### Rebuild Takes Too Long
-By default, `vde rebuild` uses `--no-cache` to ensure purity. If you are iterating quickly and want to use cache, use:
+
+If you are iterating quickly and want to use cache:
+
 ```zsh
 # Start with rebuild (inherits Docker cache)
 vde start python --rebuild
 ```
 
 ### Rebuild Doesn't Pick Up Changes
+
 Ensure you are using the standard ritual:
+
 ```zsh
 vde rebuild <vm>
 ```
 
 ### Container Won't Start After Rebuild
+
 ```zsh
 # Check logs
 vde logs <alias>
 
-# Check docker-compose.yml syntax
+# Check container info
 vde info <alias>
 ```
 

--- a/docs/operations/ssh-configuration.md
+++ b/docs/operations/ssh-configuration.md
@@ -44,7 +44,7 @@ Priority order: ed25519 > ecdsa-sk > ed25519-sk > ecdsa > rsa > dsa
 │                                                                  │
 │  ┌──────────────┐         ┌──────────────────────────────────┐ │
 │  │ VDE SSH Keys │         │ SSH Agent                        │ │
-│  │ ~/.ssh/vde/vde/  │◄────────┤ • Holds private keys             │ │
+│  │ ~/.ssh/vde/  │◄────────┤ • Holds private keys             │ │
 │  │ vde_student  │         │ • Never exposes keys directly     │ │
 │  │ ...         │         │ • Socket: $SSH_AUTH_SOCK         │ │
 │  └──────────────┘         └──────────────▲───────────────────┘ │
@@ -74,7 +74,7 @@ Priority order: ed25519 > ecdsa-sk > ed25519-sk > ecdsa > rsa > dsa
 
 ### What Happens Automatically
 
-When you run `create-virtual-for` or `start-virtual`, VDE automatically:
+When you run `vde create` or `vde start`, VDE automatically:
 
 1. **Starts SSH agent** if not running
 2. **Detects all SSH keys** in `~/.ssh/vde/`
@@ -90,12 +90,8 @@ vde create python
 vde start python
 
 # Connect using VDE commands (recommended)
-vde ssh python          # Handles SSH config automatically
-vde connect python      # Alias for 'vde ssh'
-
-# Can also use aliases
-vde ssh py             # Uses Python's alias
-vde connect py         # Same with connect
+vde enter python          # Enter the Spoke's login shell
+vde enter py             # Uses Python's alias
 
 # Or connect directly with SSH (requires -F flag)
 ssh -F ~/.ssh/vde/config vde-python
@@ -104,19 +100,6 @@ ssh -F ~/.ssh/vde/config vde-python
 alias vssh='ssh -F ~/.ssh/vde/config'
 vssh vde-python
 ```
-
-### SSH Key Types Supported
-
-VDE automatically detects and uses any of these key types:
-
-- **vde_student** (preferred)
-- **id_ecdsa**
-- **id_rsa**
-- **id_ecdsa_sk**
-- **vde_student_sk**
-- **id_dsa** (legacy)
-
-Priority order: ed25519 > ecdsa > rsa > dsa
 
 ---
 
@@ -128,12 +111,12 @@ SSH from one VM to another using your host's SSH keys:
 
 ```zsh
 # From your host
-ssh vde-go                    # Connect to Go VM
+vde enter go              # Connect to Go VM
 
-# From within Go VM
-ssh vde-python                # SSH to Python VM
-ssh vde-rust pwd              # Run command on Rust VM
-scp vde-python:/data/file .   # Copy file from Python VM
+# From within Go VM (via SSH agent forwarding)
+ssh vde-python            # SSH to Python VM
+ssh vde-rust pwd          # Run command on Rust VM
+scp vde-python:/data/file .  # Copy file from Python VM
 ```
 
 ### Full Stack Example
@@ -143,24 +126,10 @@ scp vde-python:/data/file .   # Copy file from Python VM
 vde create python postgres redis
 vde start python postgres redis
 
-# From Python VM, connect to services
-ssh vde-python
-ssh vde-postgres psql -U devuser    # Connect to PostgreSQL
-ssh vde-redis redis-cli             # Connect to Redis
-```
-
-### Microservices Example
-
-```zsh
-# Create microservices architecture
-vde create go python rust postgres
-vde start go python rust postgres
-
-# From Go VM (API gateway)
-ssh vde-go
-ssh vde-python svc_status           # Call Python service
-ssh vde-rust analytics              # Call Rust analytics
-ssh vde-postgres "psql -c 'SELECT * FROM users'"  # Query database
+# From Python VM, connect to services via DNS discovery
+vde enter python
+psql -h vde-postgres -U devuser    # Connect to PostgreSQL
+redis-cli -h vde-redis             # Connect to Redis
 ```
 
 ### SSH Config for VM-to-VM
@@ -171,7 +140,7 @@ VDE automatically generates these entries in `~/.ssh/vde/config`:
 # Python Dev VM
 Host vde-python
     HostName localhost
-    Port 2213
+    Port 2217
     User devuser
     IdentityFile ~/.ssh/vde/vde_student
     IdentitiesOnly yes
@@ -179,7 +148,7 @@ Host vde-python
 # Go Dev VM
 Host vde-go
     HostName localhost
-    Port 2206
+    Port 2208
     User devuser
     IdentityFile ~/.ssh/vde/vde_student
     IdentitiesOnly yes
@@ -192,15 +161,6 @@ This allows VMs to SSH to each other via `localhost:<port>`.
 ## VM-to-Host Communication
 
 Execute commands on your host from within any VM:
-
-### Using the `to-host` Helper
-
-```zsh
-# From within any VM
-to-host ls ~/dev                    # List host's dev directory
-to-host tail -f logs/app.log        # View host's log files
-to-host docker ps                   # Check host's containers
-```
 
 ### Direct Docker Commands
 
@@ -244,7 +204,7 @@ vde health  # Includes SSH status check
 ```
 
 This shows:
-- SSH agent running status
+- SSH agent run status
 - Available SSH keys
 - Keys loaded in agent
 - Running VMs
@@ -340,7 +300,7 @@ Regenerate VM SSH config:
 vde health
 ```
 
-### Permission Denied (Publickey)
+### Permission Denied (publickey)
 
 **Symptom**: `Permission denied (publickey)`
 
@@ -365,12 +325,12 @@ cat ~/.ssh/vde/config
 4. Rebuild VM with updated keys:
 ```zsh
 vde stop python
-vde start python --rebuild
+vde start python
 ```
 
 ### Connection Refused
 
-**Symptom**: `ssh: connect to host localhost port 2213: Connection refused`
+**Symptom**: `ssh: connect to host localhost port 2217: Connection refused`
 
 **Solutions**:
 
@@ -405,45 +365,10 @@ ssh -vvv vde-python
 
 ---
 
-## Migration from Manual Setup
-
-If you previously set up SSH manually:
-
-### Old Way (Manual)
-
-```zsh
-# 1. Generate key
-ssh-keygen -t ed25519
-
-# 2. Copy to VDE
-cp ~/.ssh/vde/vde_student.pub ~/dev/public-ssh-keys/
-
-# 3. Create SSH entry manually
-cat >> ~/.ssh/vde/config << 'EOF'
-Host vde-python
-    HostName localhost
-    Port 2213
-    User devuser
-    IdentityFile ~/.ssh/vde/vde_student
-EOF
-```
-
-### New Way (Automatic)
-
-```zsh
-# Just create VM - everything else is automatic
-vde create python
-vde start python
-```
-
-All manual steps are now handled by VDE automatically.
-
----
-
 ## Best Practices
 
 1. **Let VDE handle SSH setup**: Don't manually configure SSH agent or keys
-2. **Use VM aliases**: Use `vde-python` instead of `localhost -p 2213`
+2. **Use VM aliases**: Use `vde-python` instead of `localhost -p 2217`
 3. **Use the vde CLI**: Prefer `vde create/start/stop` over direct script calls
 4. **Check status with vde health**: Run `vde health` for comprehensive system status including SSH agent status
 5. **Multiple keys are supported**: All your keys are automatically detected and loaded
@@ -455,7 +380,7 @@ All manual steps are now handled by VDE automatically.
 
 ## Related Documentation
 
-- [Quick Start](../quick-start.md) - Getting started with VDE
+- [Quick Start](../guides/getting-started.md) - Getting started with VDE
 - [Advanced Usage](../guides/advanced-usage.md) - VM-to-VM communication patterns
 - [Architecture](../architecture/overview.md) - Technical architecture details
 - [Troubleshooting](./troubleshooting.md) - Common issues and solutions

--- a/docs/operations/vm-docker-config.md
+++ b/docs/operations/vm-docker-config.md
@@ -1,396 +1,184 @@
 # VDE VM Docker Configuration
 <!-- @shared-law (Sovereign Law) -->
 
-Centralized Docker configuration for VDE VMs in the **Sovereign Baseline (1.5.4)**.
+> **NOTE**: This document describes the conceptual Docker configuration system. The VDE uses dynamic configuration generation from `data/vm-types.json` and template files in `templates/` rather than a static `vm-docker-config.json` file.
 
 ## Overview
 
 The VM Docker configuration system provides:
 - **Centralized settings** for all language and service VMs
-- **Docker compose file** locations
+- **Dynamic compose file** generation from templates
 - **Environment file** paths
 - **Container naming** conventions
 - **Volume mount** configurations
 - **Automatic validation** against JSON schema
 
-## Configuration Files
+## Configuration Source
 
-### vm-docker-config.json
+**Authority:** `data/vm-types.json`
 
-**Location:** `data/vm-docker-config.json`
-
-**Structure:**
-```json
-{
-  "version": "1.0",
-  "base_settings": {
-    "context": "../../..",
-    "base_dockerfile": "configs/docker/vde-base.Dockerfile",
-    "network": "vde-net",
-    "username": "devuser",
-    "uid": 1000,
-    "gid": 1000
-  },
-  "languages": {
-    "python": {
-      "compose_file": "configs/docker/python/docker-compose.yml",
-      "env_file": "env-files/python.env",
-      "image": "dev-python:latest",
-      "container_name": "vde-python",
-      "workspace_mount": "projects/python:$HOME/workspace/",
-      "logs_mount": "logs/python:/logs"
-    }
-  },
-  "services": {
-    "postgres": {
-      "compose_file": "configs/docker/postgres/docker-compose.yml",
-      "env_file": "env-files/postgres.env",
-      "image": "dev-postgres:latest",
-      "container_name": "postgres",
-      "data_mount": "data/postgres:/data",
-      "logs_mount": "logs/postgres:/logs"
-    }
-  }
-}
-```
-
-### vm-docker-config.schema.json
-
-**Location:** `data/vm-docker-config.schema.json`
-
-**Validates:**
-- Base settings structure
-- Language VM requirements
-- Service VM requirements
-- File path patterns
-- Container naming conventions
-
-## Fields
-
-### Base Settings
-
-Shared across all VMs:
+The Beskar Registry (`data/vm-types.json`) is the single source of truth for VM definitions. Each VM entry contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `context` | string | Docker build context path |
-| `base_dockerfile` | string | Path to base Dockerfile |
-| `network` | string | Docker network name |
-| `username` | string | Container username |
-| `uid` | integer | User ID (≥1000) |
-| `gid` | integer | Group ID (≥1000) |
+| `name` | string | Unique VM identifier (e.g., `vde-python`) |
+| `aliases` | array | Alternative names for user convenience |
+| `display` | string | Human-readable name |
+| `pkgs` | string | Required system packages (empty for build-time) |
+| `custom_cmd` | string | Initialization/hydration script path |
+| `service_ports` | string | Service port(s) for service VMs |
+| `ssh_port` | integer | SSH port assignment |
 
-### Language VM Config
+## Docker Build System
 
-Each language VM has:
+### Base Images
 
-| Field | Type | Pattern | Description |
-|-------|------|---------|-------------|
-| `compose_file` | string | `configs/docker/{lang}/docker-compose.yml` | Docker compose file location |
-| `env_file` | string | `env-files/{lang}.env` | Environment variables file |
-| `image` | string | `dev-{lang}:latest` | Docker image name |
-| `container_name` | string | `{lang}-dev` | Container name (must end with `-dev`) |
-| `workspace_mount` | string | `projects/{lang}:$HOME/workspace/` | Workspace volume mount |
-| `logs_mount` | string | `logs/{lang}:/logs` | Logs volume mount |
+- **vde-base**: Foundational image with Zsh, Git, Docker CLI, SSH, socat
+- **vde-lang**: Language VM image (inherits from vde-base, uses build args for packages)
 
-### Service VM Config
+**Location:** `configs/docker/`
 
-Each service VM has:
+### Configuration Files
 
-| Field | Type | Pattern | Description |
-|-------|------|---------|-------------|
-| `compose_file` | string | `configs/docker/{service}/docker-compose.yml` | Docker compose file location |
-| `env_file` | string | `env-files/{service}.env` | Environment variables file |
-| `image` | string | `dev-{service}:latest` | Docker image name |
-| `container_name` | string | `{service}` | Container name (no `-dev` suffix) |
-| `data_mount` | string | `data/{service}:/data` | Data volume mount |
-| `logs_mount` | string | `logs/{service}:/logs` | Logs volume mount |
+| File | Purpose |
+|------|---------|
+| `configs/docker/vde-base.Dockerfile` | Base image with core tools |
+| `configs/docker/vde-lang.Dockerfile` | Language VM image with build-time package installation |
+| `env-files/*.env` | Per-VM environment variables |
+
+### Container Naming
+
+- Language VMs: `vde-<alias>` (e.g., `vde-python`)
+- Service VMs: `vde-<alias>` (e.g., `vde-postgres`)
+
+### Volume Mounts
+
+- **Workspace**: `projects/<alias>:$HOME/workspace/` (language VMs)
+- **Data**: `data/<alias>:/data` (service VMs)
+- **Logs**: `logs/<alias>:/logs` (all VMs)
+- **SSH Agent**: Host socket mounted read-only
 
 ## Usage
 
-### Load Docker Config
+### Load VM Types
 
 ```zsh
-source lib/vm-common
-load_docker_config
+source "${VDE_ROOT_DIR}/lib/vm-common"
+load_vm_types
 ```
 
-Output:
-```
-[INFO] Loading VM Docker configuration...
-[INFO] Validating docker config against schema...
-[INFO] Schema validation passed
-[INFO] Docker config loaded successfully
-[INFO]   Language configs: 20
-[INFO]   Service configs: 7
-```
-
-### Access Configuration
-
-**Using associative arrays:**
-```zsh
-echo ${VM_COMPOSE_FILE[python]}
-# Output: configs/docker/python/docker-compose.yml
-
-echo ${VM_ENV_FILE[python]}
-# Output: env-files/python.env
-
-echo ${VM_CONTAINER_NAME[python]}
-# Output: vde-python
-
-echo ${VM_WORKSPACE_MOUNT[python]}
-# Output: projects/python:$HOME/workspace/
-```
-
-**Using helper function:**
-```zsh
-get_docker_config COMPOSE_FILE python
-# Output: configs/docker/python/docker-compose.yml
-
-get_docker_config ENV_FILE postgres
-# Output: env-files/postgres.env
-
-get_docker_config DATA_MOUNT postgres
-# Output: data/postgres:/data
-```
-
-### Available Arrays
-
-**All VMs:**
-- `VM_COMPOSE_FILE` - Docker compose file paths
-- `VM_ENV_FILE` - Environment file paths
-- `VM_IMAGE` - Docker image names
-- `VM_CONTAINER_NAME` - Container names
-- `VM_LOGS_MOUNT` - Logs mount configurations
-
-**Language VMs only:**
-- `VM_WORKSPACE_MOUNT` - Workspace mount configurations
-
-**Service VMs only:**
-- `VM_DATA_MOUNT` - Data mount configurations
-
-## Schema Validation
-
-### Automatic Validation
-
-Validation happens automatically when loading:
+### Access VM Configuration
 
 ```zsh
-load_docker_config
-# Validates against vm-docker-config.schema.json
+# Get VM SSH port
+get_vm_ssh_port "python"
+# Output: 2217
+
+# Get VM hydration script
+vde_get_hydration_script "python"
+# Output: zsh /vde/scripts/setup/python-init.zsh
+
+# Resolve VM name from alias
+resolve_vm_name "py"
+# Output: python
 ```
 
-### Manual Validation
+### Validate Configuration
 
 ```zsh
-# Using validation script
-./bin/validate-schemas.zsh
-
-# Using vde-core directly
-source lib/vde-core
-schema=$(vde_get_schema_for_json "data/vm-docker-config.json")
-vde_validate_json_schema "data/vm-docker-config.json" "$schema"
+# Validate Beskar Registry against schema
+vde validate
 ```
 
 ## Validation Rules
 
 ### Language VMs
-
-- ✓ Container name must end with `-dev`
-- ✓ Must have `workspace_mount` (not `data_mount`)
-- ✓ Compose file: `configs/docker/{lang}/docker-compose.yml`
-- ✓ Env file: `env-files/{lang}.env`
-- ✓ Image: `dev-{lang}:latest`
+- Must have unique name and SSH port in 2200–2299 range
+- Must have a corresponding hydration script in `scripts/setup/`
+- Container name: `vde-<name>`
 
 ### Service VMs
-
-- ✓ Container name must NOT end with `-dev`
-- ✓ Must have `data_mount` (not `workspace_mount`)
-- ✓ Compose file: `configs/docker/{service}/docker-compose.yml`
-- ✓ Env file: `env-files/{service}.env`
-- ✓ Image: `dev-{service}:latest`
-
-## Examples
-
-### Example 1: Get Compose File Path
-
-```zsh
-source lib/vm-common
-load_docker_config
-
-compose_file=$(get_docker_config COMPOSE_FILE python)
-echo "Python compose file: $compose_file"
-# Output: Python compose file: configs/docker/python/docker-compose.yml
-```
-
-### Example 2: Launch Container with Config
-
-```zsh
-source lib/vm-common
-load_docker_config
-
-vm_name="python"
-compose_file="${VM_COMPOSE_FILE[$vm_name]}"
-env_file="${VM_ENV_FILE[$vm_name]}"
-
-docker-compose -f "$compose_file" --env-file "$env_file" up -d
-```
-
-### Example 3: Check All Language VMs
-
-```zsh
-source lib/vm-common
-load_docker_config load_vm_types
-
-for vm in "${(@k)VM_TYPE}"; do
-    if [[ "${VM_TYPE[$vm]}" == "lang" ]]; then
-        echo "$vm: ${VM_COMPOSE_FILE[$vm]}"
-    fi
-done
-```
-
-### Example 4: Validate Mount Paths
-
-```zsh
-source lib/vm-common
-load_docker_config
-
-for vm in python rust go; do
-    workspace="${VM_WORKSPACE_MOUNT[$vm]}"
-    logs="${VM_LOGS_MOUNT[$vm]}"
-    echo "$vm workspace: $workspace"
-    echo "$vm logs: $logs"
-done
-```
-
-## Integration with VM Types
-
-The Docker config complements the VM types config:
-
-**vm-types.json** provides:
-- VM metadata (name, display, aliases)
-- Installation commands
-- Service ports
-- VM type (lang/service)
-
-**vm-docker-config.json** provides:
-- Docker compose file locations
-- Environment file paths
-- Container names
-- Volume mounts
-- Image names
-
-**Together they provide complete VM configuration.**
+- Must have unique name and SSH port in 2400–2499 range
+- Must have `service_ports` defined
+- Must have a corresponding hydration script in `scripts/setup/`
+- Container name: `vde-<name>`
 
 ## File Structure
 
 ```
 VDE Project Root
 ├── data/
-│   ├── vm-types.json              # VM metadata
-│   ├── vm-types.schema.json       # VM types schema
-│   ├── vm-docker-config.json      # Docker config (NEW)
-│   └── vm-docker-config.schema.json  # Docker config schema (NEW)
+│   ├── vm-types.json              # VM metadata (AUTHORITY)
+│   └── vm-types.schema.json       # VM types schema
 ├── configs/docker/
+│   ├── vde-base.Dockerfile        # Base image
+│   ├── vde-lang.Dockerfile        # Language VM image
 │   ├── python/
-│   │   └── docker-compose.yml     # Referenced by config
-│   ├── postgres/
-│   │   └── docker-compose.yml     # Referenced by config
+│   │   └── docker-compose.yml     # Generated compose file
 │   └── ...
-└── env-files/
-    ├── python.env                 # Referenced by config
-    ├── postgres.env               # Referenced by config
+├── env-files/
+│   ├── python.env                 # Per-VM environment
+│   └── ...
+└── scripts/setup/
+    ├── python-init.zsh            # Hydration ritual
     └── ...
 ```
 
-## Benefits
+## Integration with VM Types
 
-1. **Single Source of Truth**: All Docker paths in one place
-2. **Type Safety**: Schema validation prevents errors
-3. **Consistency**: Enforces naming conventions
-4. **Maintainability**: Easy to add new VMs
-5. **Integration**: Works with existing VM types config
-6. **Validation**: Automatic schema validation
+**vm-types.json** provides the complete VM configuration:
+- VM metadata (name, display, aliases)
+- Service ports
+- VM type (lang/service)
+- SSH port assignment
+- Hydration script path
 
 ## Adding New VMs
 
-### Add Language VM
+Use the `vde add` command to register new VM types:
 
-```json
-{
-  "newlang": {
-    "compose_file": "configs/docker/newlang/docker-compose.yml",
-    "env_file": "env-files/newlang.env",
-    "image": "dev-newlang:latest",
-    "container_name": "vde-newlang",
-    "workspace_mount": "projects/newlang:$HOME/workspace/",
-    "logs_mount": "logs/newlang:/logs"
-  }
-}
-```
+```zsh
+# Add a language VM
+vde add --pkgs "htop,tree" my-custom-vm
 
-### Add Service VM
-
-```json
-{
-  "newservice": {
-    "compose_file": "configs/docker/newservice/docker-compose.yml",
-    "env_file": "env-files/newservice.env",
-    "image": "dev-newservice:latest",
-    "container_name": "newservice",
-    "data_mount": "data/newservice:/data",
-    "logs_mount": "logs/newservice:/logs"
-  }
-}
+# Add a service VM with specific ports
+vde add --type service --port 5000 my-api
 ```
 
 ### Validation After Changes
 
 ```zsh
 # Validate schema
-./bin/validate-schemas.zsh
+vde validate
 
-# Test loading
-zsh -c "source lib/vm-common && load_docker_config"
+# Force cache re-smelt
+vde rebuild-cache
 ```
 
 ## Troubleshooting
 
-### "Docker config validation failed"
+### "Schema validation failed"
 
-**Cause**: Config doesn't match schema
+**Cause**: vm-types.json doesn't match schema
 
 **Solution**:
-1. Check JSON syntax: `jq . data/vm-docker-config.json`
+1. Check JSON syntax
 2. Verify required fields present
-3. Check naming patterns (container names, file paths)
-4. Run validation: `./bin/validate-schemas.zsh`
+3. Check naming patterns and port ranges
+4. Run validation: `vde validate`
 
-### "Docker config not found"
+### "VM not found"
 
-**Cause**: Missing config file
-
-**Solution**:
-```zsh
-# Check file exists
-ls -la data/vm-docker-config.json
-
-# Regenerate if missing
-# (File must be created manually, no auto-generation)
-```
-
-### "Field not found for VM"
-
-**Cause**: VM not in docker config
+**Cause**: VM not in vm-types.json
 
 **Solution**:
-1. Check VM exists: `jq '.languages, .services | keys' data/vm-docker-config.json`
-2. Add VM to config if missing
-3. Reload config: `load_docker_config`
+1. Check VM exists: `vde list`
+2. Add VM if missing: `vde add <name>`
+3. Rebuild cache: `vde rebuild-cache`
 
 ## References
 
 - **JSON Schema Spec**: https://json-schema.org/
-- **VM Types Config**: `data/README.md`
-- **Schema Validation**: `docs/architecture/overview.md`
-- **Validation Tool**: `bin/validate-schemas.zsh`
+- **VM Types Config**: `data/vm-types.json`
+- **Schema Validation**: `vde validate`
+- **VM Type Library**: `lib/vm-common`


### PR DESCRIPTION
## Fracture Analysis

Multiple docs/operations/ files contained references to non-existent commands, files, and stale configurations:

1. **mcp-configuration.md** — Referenced `.gemini/settings.json` (doesn't exist), `gemini mcp add` (Gemini CLI command), Redis MCP setup (irrelevant to VDE)
2. **ssh-configuration.md** — Referenced `vde connect` (doesn't exist), `create-virtual-for` / `start-virtual` (non-existent old commands), `to-host` helper (unverified)
3. **vm-docker-config.md** — Documented `data/vm-docker-config.json` which does NOT exist
4. **rebuild-guidelines.md** — Referenced `create-virtual-for` / `start-virtual` (non-existent)

## The Reforging

- **mcp-configuration.md**: Rewritten for Kilo configuration, removed Gemini CLI references, removed Redis MCP, updated to reference kilo.json and context7
- **ssh-configuration.md**: Removed `vde connect` references, replaced `create-virtual-for`/`start-virtual` with `vde create`/`vde start`, updated SSH ports to match vm-types.json, fixed architecture diagram path
- **vm-docker-config.md**: Rewritten to describe actual dynamic config generation from vm-types.json and templates instead of non-existent vm-docker-config.json
- **rebuild-guidelines.md**: Replaced non-existent command references with canonical `vde rebuild` commands, fixed docker-compose references

## The Beskar Set

- `docs/operations/mcp-configuration.md`
- `docs/operations/ssh-configuration.md`
- `docs/operations/vm-docker-config.md`
- `docs/operations/rebuild-guidelines.md`

## Unbreakable Link

Closes #420

## Architectural Tagging

| Path | Domain | Functional Effect |
| :--- | :--- | :--- |
| docs/operations/*.md | @shared-law | Operations Documentation Corrections |