### PR TITLE
fix(security): remove dead POSTGRES_DEV_PASSWORD ARG from Dockerfile

### DIFF
--- a/configs/docker/vde-lang.Dockerfile
+++ b/configs/docker/vde-lang.Dockerfile
@@ -6,7 +6,6 @@ FROM vde-base:latest
 ARG VM_NAME
 ARG PKGS_TO_INSTALL=""
 ARG CUSTOM_BUILD_CMD=""
-ARG POSTGRES_DEV_PASSWORD=""
 LABEL project="vde" \
       component="spoke" \
       vde.managed="true"


### PR DESCRIPTION
## Fracture Analysis
Docker Scout reported a `SecretsUsedInArgOrEnv` warning for `configs/docker/vde-lang.Dockerfile`. `ARG POSTGRES_DEV_PASSWORD=""` was declared but never referenced in the build process.

## The Reforging
Removed the dead ARG. Runtime secrets are correctly injected at the container level via docker-compose, which remains unchanged.

## The Beskar Set
- `configs/docker/vde-lang.Dockerfile` (@shared-law)

## Sentinel Clearance
- [ ] kilo-code-bot: CLEAR
- [ ] sourcery-ai: CLEAR
- [ ] dependabot: CLEAR
- [ ] CodeQL: CLEAR

Closes #431