### PR TITLE
fix(security): remove build-time secret injection from service compose files

### DIFF
--- a/configs/docker/services/couchdb/docker-compose.yml
+++ b/configs/docker/services/couchdb/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: couchdb
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/couchdb-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/jupyterlab/docker-compose.yml
+++ b/configs/docker/services/jupyterlab/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: jupyterlab
         PKGS_TO_INSTALL: "python3-pip python3-venv tini"
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/jupyterlab-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/mongodb/docker-compose.yml
+++ b/configs/docker/services/mongodb/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: mongodb
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/mongodb-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/mysql/docker-compose.yml
+++ b/configs/docker/services/mysql/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: mysql
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/mysql-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/nginx/docker-compose.yml
+++ b/configs/docker/services/nginx/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: nginx
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/nginx-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/postgres/docker-compose.yml
+++ b/configs/docker/services/postgres/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: postgres
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/postgres-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/rabbitmq/docker-compose.yml
+++ b/configs/docker/services/rabbitmq/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: rabbitmq
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/rabbitmq-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000

--- a/configs/docker/services/redis/docker-compose.yml
+++ b/configs/docker/services/redis/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         VM_NAME: redis
         PKGS_TO_INSTALL: ""
         CUSTOM_BUILD_CMD: "zsh /vde/scripts/setup/redis-init.zsh"
-        POSTGRES_DEV_PASSWORD: "${POSTGRES_DEV_PASSWORD}"
         USERNAME: devuser
         UID: 1000
         GID: 1000


### PR DESCRIPTION
## Fracture Analysis
`POSTGRES_DEV_PASSWORD` was incorrectly passed as a build argument in service `docker-compose.yml` files, which could lead to sensitive data being baked into Docker image layers.

## The Reforging
Removed the redundant `POSTGRES_DEV_PASSWORD` build argument from the following services:
- couchdb
- jupyterlab
- mongodb
- mysql
- nginx
- postgres
- rabbitmq
- redis

Runtime injection continues to be handled safely via `env_file`.

## The Beskar Set
- `configs/docker/services/*/docker-compose.yml` (@shared-law)

## Sentinel Clearance
- [ ] kilo-code-bot: CLEAR
- [ ] sourcery-ai: CLEAR
- [ ] dependabot: CLEAR
- [ ] CodeQL: CLEAR

Closes #433