### PR TITLE
fix(forge): exclude projects/ (Student Space) from security audit scan

### DIFF
--- a/bin/vde-security-audit.zsh
+++ b/bin/vde-security-audit.zsh
@@ -25,7 +25,7 @@ fi
 # 3. Privacy Leak Guard (Absolute Path Detection)
 echo "[SECURITY] Scanning for Absolute Path Leaks..."
 # Exclude dirs and files shared by both the counting and display grep passes
-typeset -a _scan_exclude_dirs=(.git .cache .claude .tmp.driveupload .tmp.drivedownload logs node_modules __pycache__ SKILLS output)
+typeset -a _scan_exclude_dirs=(.git .cache .claude .tmp.driveupload .tmp.drivedownload logs node_modules __pycache__ SKILLS output projects)
 typeset -a _scan_exclude_files=(vde-security-audit.zsh vde-root-guard README.md)
 typeset -a _grep_excludes=()
 for _d in "${_scan_exclude_dirs[@]}"; do _grep_excludes+=(--exclude-dir="${_d}"); done


### PR DESCRIPTION
<!-- @forge (Governance Sentinel) -->

## PR: Submission of Beskar

### I. Context (The Why)
`projects/` is sovereign Student Space. VDE has no jurisdiction over its contents.
Compiled artifacts in `projects/rust/vde-system2/target/` embed host paths (normal
for toolchains) and caused false-positive `[CRITICAL]` failures on every UAP run,
blocking all pushes including unrelated fixes.

### II. Signet Link (The Unbreakable Link)
Closes #446

### III. The Trial of the Gauntlet (Test Evidence)
- [x] Red Gauntlet: UAP run confirming `[CRITICAL] Absolute Path Leaks Detected` before fix
- [x] Green Victory: `vde-security-audit.zsh` exits 0 after adding `projects` to `_scan_exclude_dirs`

### IV. Files Changed (The Beskar Plates)
| File | Change |
|:---|:---|
| `bin/vde-security-audit.zsh` | Added `projects` to `_scan_exclude_dirs` array (line 28) |

### V. Refactoring Rationale (The Refiner's Fire)
Single token added to an existing exclusion array. No logic change. Pattern matches all existing exclusions (`.git`, `node_modules`, etc.) — Student Space is simply another directory VDE must never govern.

### VI. Discussion Summary (The Signet's Record)
Root cause: `_scan_exclude_dirs` did not list `projects/`. Fix: add `projects`. One word, one line.

### VII. Checklist of the Creed
- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified (6/6 — 2026-05-19)
- [ ] Dual-Gate Review complete
- [x] Documentation updated (N/A — single-line config change)

### Sentinel Clearance
- [ ] kilo-code-bot: PENDING
- [ ] sourcery-ai: PENDING
- [ ] dependabot: CLEAR
- [ ] CodeQL: CLEAR

### Final Architectural Tagging Report
| Path | Domain | Functional Effect |
|:---|:---|:---|
| `bin/vde-security-audit.zsh` | @forge | Governance Sentinel — correct Student Space exclusion from path-leak scan |

## Summary by Sourcery

Bug Fixes:
- Prevent false-positive absolute path leak failures by excluding the projects directory from security audit scans.