### PR TITLE
fix(armor): add zshexit hook to release locks on WSL2 ZSH 5.8.x

### DIFF
--- a/lib/vm-lock
+++ b/lib/vm-lock
@@ -169,3 +169,29 @@ release_lock() {
     fi
     return 0
 }
+
+# ZSH 5.8.x on WSL2/Ubuntu does not reliably fire {always} blocks on function return,
+# leaving global-config.lock and queue tickets on disk after every vde invocation.
+# This hook fires unconditionally on shell exit, bypassing the always path entirely.
+_vde_lock_cleanup_on_exit() {
+    local locks_dir="${VDE_LOCKS_DIR:-${VDE_ROOT_DIR}/.locks}"
+    local vms_dir="${VDE_VM_LOCKS_DIR:-${locks_dir}/vms}"
+    [[ -d "${locks_dir}" ]] || return 0
+
+    local q ticket ld pf pd
+    for q in "${locks_dir}"/*.queue(N/) "${vms_dir}"/*.queue(N/); do
+        for ticket in "${q}/"*-$$(N); do
+            rm -f "${ticket}" 2>/dev/null
+        done
+    done
+
+    for ld in "${locks_dir}"/*.lock(N/) "${vms_dir}"/*.lock(N/); do
+        pf="${ld}/pid"
+        [[ -f "${pf}" ]] || continue
+        pd=$(< "${pf}" 2>/dev/null)
+        [[ "${pd%%:*}" == "$$" ]] && rm -rf "${ld}" 2>/dev/null
+    done
+}
+
+autoload -U add-zsh-hook 2>/dev/null
+add-zsh-hook zshexit _vde_lock_cleanup_on_exit 2>/dev/null

--- a/lib/vm-lock
+++ b/lib/vm-lock
@@ -193,5 +193,9 @@ _vde_lock_cleanup_on_exit() {
     done
 }
 
-autoload -U add-zsh-hook 2>/dev/null
-add-zsh-hook zshexit _vde_lock_cleanup_on_exit 2>/dev/null
+# add-zsh-hook is idempotent; guard against subshell registration so the hook
+# does not fire on $() or nested-shell exit and remove locks the parent still holds.
+if [[ ${ZSH_SUBSHELL:-0} -eq 0 ]]; then
+    autoload -U add-zsh-hook 2>/dev/null
+    add-zsh-hook zshexit _vde_lock_cleanup_on_exit 2>/dev/null
+fi


### PR DESCRIPTION
<!-- @armor (Engine Core) -->

## PR: Submission of Beskar

### I. Context (The Why)
ZSH 5.8.1 on WSL2/Ubuntu has a known defect where `{always}` blocks do not
reliably fire when a function exits via `return` in certain call contexts.
`lib/vm-common:load_vm_types()` and `lib/vde-core:vde_translate_conf_to_json()`
both rely on `{...} always {...}` to guarantee `release_lock()` is called on exit.
On affected systems, `global-config.lock` and queue tickets survive the process,
causing every subsequent `vde` command to emit WARN stale-lock messages.

This adds `_vde_lock_cleanup_on_exit()` registered via `add-zsh-hook zshexit` as
an unconditional safety net — fires on every shell exit regardless of whether the
`always` path executed, removes only lock dirs/tickets owned by the current `$$`
(no cross-process risk).

### II. Signet Link (The Unbreakable Link)
Closes #445

### III. The Trial of the Gauntlet (Test Evidence)
- [x] Red Gauntlet: Stale-lock WARN reproduced on WSL2 ZSH 5.8.1 before fix
- [x] Green Victory: Empirical verification on affected WSL2 environment by user
> NOTE: ZSH 5.8.x cannot be exercised in macOS test environment (ZSH 5.9).
> PoL 6/6 certified on macOS (2026-05-19).

### IV. Files Changed (The Beskar Plates)
| File | Change |
|:---|:---|
| `lib/vm-lock` | Added `_vde_lock_cleanup_on_exit()` + `zshexit` hook registration |

### V. Refactoring Rationale (The Refiner's Fire)
Additive-only change. Does not modify existing `release_lock()` or `claim_lock()`
logic. `zshexit` is compatible with `bin/vde`'s existing `trap EXIT` handler.
Single-file scope — pure @armor, no Forge or shared-law surface touched.

### VI. Discussion Summary (The Signet's Record)
Full root cause analysis documented in Issue #445. ZSH 5.8.x `always`-block
defect is the root cause; `zshexit` hook is the lowest-risk, version-targeted fix.

### VII. Checklist of the Creed
- [x] Focused Strike (scope limited to Signet)
- [x] Enforcer passed
- [x] Rule Spine green
- [x] Heartbeat certified (6/6 — 2026-05-19)
- [ ] Dual-Gate Review complete
- [ ] Documentation updated

### Sentinel Clearance
- [ ] kilo-code-bot: PENDING
- [ ] sourcery-ai: PENDING
- [ ] dependabot: CLEAR
- [ ] CodeQL: CLEAR

### Final Architectural Tagging Report
| Path | Domain | Functional Effect |
|:---|:---|:---|
| `lib/vm-lock` | @armor | Engine Core — runtime locking reliability on ZSH 5.8.x WSL2 |

## Summary by Sourcery

Add a zshexit-based cleanup mechanism to ensure VM lock directories and queue tickets are reliably released on shell exit, particularly on WSL2 systems running ZSH 5.8.x.

Bug Fixes:
- Ensure stale lock directories and queue tickets are cleaned up on shell exit when ZSH 5.8.x fails to execute always blocks that call release_lock().

Enhancements:
- Register a zshexit hook that performs per-process lock cleanup as a safety net alongside existing locking and EXIT trap logic.