### PR TITLE
feat(base): inject TERM override for ghostty into devuser ~/.zshrc

### DIFF
--- a/configs/docker/vde-base.Dockerfile
+++ b/configs/docker/vde-base.Dockerfile
@@ -59,6 +59,10 @@ WORKDIR /home/devuser
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended && \
     git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 
+# Force xterm-256color when connecting from ghostty.
+# xterm-ghostty terminfo is not installed on this host.
+RUN printf 'if [[ "$TERM" == "xterm-ghostty" ]]; then\n    export TERM=xterm-256color\nfi\n' >> ~/.zshrc
+
 # 5. SSH Key Preparation
 # The VDE public key is injected dynamically via the entrypoint (Option B)
 RUN mkdir -p /home/devuser/.ssh/vde && \


### PR DESCRIPTION
## Summary

- Appends a `TERM` guard to `~/.zshrc` inside `vde-base.Dockerfile`, covering all Spoke types universally
- Guard fires at every SSH login: if `TERM=xterm-ghostty`, it silently degrades to `xterm-256color`
- Single source of truth — no per-language duplication needed in individual hydration scripts

## Why

`xterm-ghostty` terminfo is absent on VDE Spokes. Ghostty connections set `TERM=xterm-ghostty`, breaking `vim`, `less`, `tmux`, and any curses application. The base image is the correct home for this fix.

## Test plan

- [ ] `bin/vde rebuild python` (or any Spoke) and `bin/vde enter python 'grep -A3 xterm-ghostty ~/.zshrc'` confirms block is present
- [ ] SSH in from Ghostty; confirm `echo $TERM` outputs `xterm-256color`
- [ ] Proof of Life: `python3 -m behave tests/features/core-infrastructure/proof-of-life-the-contract.feature`

Closes #454

## Summary by Sourcery

Enhancements:
- Append a conditional TERM override snippet to devuser’s ~/.zshrc in the base Docker image so Ghostty sessions use xterm-256color instead of xterm-ghostty.